### PR TITLE
Fix bug in subroutine for comparing tags (match_tag_list)

### DIFF
--- a/utils/feature_test_utils.py
+++ b/utils/feature_test_utils.py
@@ -9,12 +9,11 @@ def match_tag_list(feature, master_tags):#{{{
 	
 	feature_tag_list = feature_tags.split(';')
 
-	test = True
+	test = False
 	for tag in master_tags:
 		if tag in feature_tag_list:
-			test = test and True
-		else:
-			test = test and False
+			test = True
+			break
 
 	return test
 #}}}


### PR DESCRIPTION
Previously, match_tag_list would always return False for multiple input tags in the previous version.  Now, match_tag_list returns true if the any of the requested tags are present in a given feature.