### PR TITLE
Add groupName for features

### DIFF
--- a/merge_features.py
+++ b/merge_features.py
@@ -87,6 +87,7 @@ if args.features_dir:
 				del feature_file
 
 out_file.write('{"type": "FeatureCollection",\n')
+out_file.write(' "groupName": "enterNameHere",\n')
 out_file.write(' "features":\n')
 out_file.write('\t[\n')
 write_all_features(all_features, out_file, '\t\t')


### PR DESCRIPTION
This merge adds groupName as an attribute on a features file. This
allows multiple feature files to be pass into a feature parsing tool
with each file having a name.