### PR TITLE
Fix several issues with difference_features.py

### DIFF
--- a/utils/feature_write_utils.py
+++ b/utils/feature_write_utils.py
@@ -1,5 +1,6 @@
 #!/use/bin/env python
 import json
+import sys
 
 def write_all_features(features, out_file, base_indent):#{{{
 	first_feature = True


### PR DESCRIPTION
This merge modifies the difference_features.py script to handle cases where:

1. a feature does not intersect the mask at all (so nothing should happen)
2. a feature intersects the mask completely so it should be removed entirely.

Features already in features.geojson are now retained but the mask is not applied to these features, only to those being added.

Also, a missing `import sys` is added to a utils script.
