### PR TITLE
Fix typo Penninsula --> Peninsula in landice tag

### DIFF
--- a/landice/region/Antarctica_IMBIE24/region.geojson
+++ b/landice/region/Antarctica_IMBIE24/region.geojson
@@ -5,7 +5,7 @@
 		 "properties": {
 			"name": "Antarctica_IMBIE24",
 			"component": "landice",
-			"tags": "AntarcticPenninsulaIMBIE;WilkinsGeorgeVIceShelfDrainage",
+			"tags": "WilkinsGeorgeVIceShelfDrainage;AntarcticPeninsulaIMBIE",
 			"author": "http://icesat4.gsfc.nasa.gov/cryo_data/ant_grn_drainage_systems.php",
 			"object": "region"
 		 },

--- a/landice/region/Antarctica_IMBIE25/region.geojson
+++ b/landice/region/Antarctica_IMBIE25/region.geojson
@@ -5,7 +5,7 @@
 		 "properties": {
 			"name": "Antarctica_IMBIE25",
 			"component": "landice",
-			"tags": "AntarcticPenninsulaIMBIE",
+			"tags": "AntarcticPeninsulaIMBIE",
 			"author": "http://icesat4.gsfc.nasa.gov/cryo_data/ant_grn_drainage_systems.php",
 			"object": "region"
 		 },

--- a/landice/region/Antarctica_IMBIE26/region.geojson
+++ b/landice/region/Antarctica_IMBIE26/region.geojson
@@ -5,7 +5,7 @@
 		 "properties": {
 			"name": "Antarctica_IMBIE26",
 			"component": "landice",
-			"tags": "AntarcticPenninsulaIMBIE;LarsenCIceShelfDrainage",
+			"tags": "LarsenCIceShelfDrainage;AntarcticPeninsulaIMBIE",
 			"author": "http://icesat4.gsfc.nasa.gov/cryo_data/ant_grn_drainage_systems.php",
 			"object": "region"
 		 },

--- a/landice/region/Antarctica_IMBIE27/region.geojson
+++ b/landice/region/Antarctica_IMBIE27/region.geojson
@@ -5,7 +5,7 @@
 		 "properties": {
 			"name": "Antarctica_IMBIE27",
 			"component": "landice",
-			"tags": "AntarcticPenninsulaIMBIE",
+			"tags": "AntarcticPeninsulaIMBIE",
 			"author": "http://icesat4.gsfc.nasa.gov/cryo_data/ant_grn_drainage_systems.php",
 			"object": "region"
 		 },


### PR DESCRIPTION
Fixes the tag "AntarticPeninsulaIMBIE", where peninsula was previously spelled with a double n.