### PR TITLE
Add preservation of all properties in a feature

### DIFF
--- a/utils/feature_write_utils.py
+++ b/utils/feature_write_utils.py
@@ -17,42 +17,56 @@ def write_single_feature(feature, out_file, base_indent):#{{{
 	out_file.write('%s{"type": "Feature",\n'%(base_indent))
 	out_file.write('%s "properties": {\n'%(base_indent))
 
+	# Set property values that need to be set...
+	if not 'name' in feature['properties'].keys():
+		print "There was an error getting the name property from a feature. Exiting...\n"
+		sys.exit(1)
+
+	if not 'component' in feature['properties'].keys():
+		print "Feature %s has an issue with the component property. Exiting...\n"%(feature['properties']['name'])
+		sys.exit(1)
+
+	if not 'author' in feature['properties'].keys():
+		feature['properties']['author'] = ""
+
+	if not 'tags' in feature['properties'].keys():
+		feature['properties']['tags'] = ""
+	
+	if not 'type' in feature['geometry'].keys():
+		print "Feature %s has an issue with the geometry type. Exiting...\n"%(feature['properties']['name'])
+		sys.exit(1)
+	
+	feature_type = feature['geometry']['type']
+
+	# Determine object property value based on feature type.
+	if feature_type == "Polygon" or feature_type == "MultiPolygon":
+		object_type = "region"
+	elif feature_type == "LineString" or feature_type == "MultiLineString":
+		object_type = "transect"
+	elif feature_type == "Point":
+		object_type = "point"
+
+	feature['properties']['object'] = object_type
+
+	write_comma = False
+
+	for key in sorted(feature['properties'].keys()):
+		if write_comma:
+			out_file.write(",\n")
+
+		out_file.write('%s\t"%s": "%s"'%(base_indent, key, feature['properties'][key]))
+
+		write_comma = True
+
+	out_file.write("\n")
+
 	# Write out properties
-	try:
-		out_file.write('%s\t"name": "%s",\n'%(base_indent, feature['properties']['name']))
-	except:
-		print "There was an error getting the name property from a feature. Existing...\n"
-		quit(1)
-
-	try:
-		out_file.write('%s\t"component": "%s",\n'%(base_indent, feature['properties']['component']))
-	except:
-		print "Feature %s has an issue with the component property. Exiting...\n"%(feature['properties']['component'])
-		quit(1)
-
-	try:
-		out_file.write('%s\t"tags": "%s",\n'%(base_indent, feature['properties']['tags']))
-	except:
-		out_file.write('%s\t"tags": "",\n'%(base_indent))
-
-	try:
-		out_file.write('%s\t"author": "%s",\n'%(base_indent, feature['properties']['author']))
-	except:
-		out_file.write('%s\t"author": "http://www.marineregions.org/downloads.php#iho",\n'%(base_indent))
-
 	try:
 		feature_type = feature['geometry']['type']
 	except:
 		print "Feature: %s has an issue with the type of geometry. Exiting...\n"%(feature['properties']['name'])
 		quit(1)
-	
-	# Determine object property value based on feature type.
-	if feature_type == "Polygon" or feature_type == "MultiPolygon":
-		out_file.write('%s\t"object": "region"\n'%(base_indent))
-	elif feature_type == "LineString" or feature_type == "MultiLineString":
-		out_file.write('%s\t"object": "transect"\n'%(base_indent))
-	elif feature_type == "Point":
-		out_file.write('%s\t"object": "point"\n'%(base_indent))
+
 		
 	out_file.write('%s },\n'%(base_indent))
 


### PR DESCRIPTION
This ensures that all properties of a feature are preserved when merging
/ splitting them between feature files.