### PR TITLE
Alphabetize keys for all region properties

### DIFF
--- a/iceshelves/region/Abbot/region.geojson
+++ b/iceshelves/region/Abbot/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Abbot",
-			"component": "iceshelves",
-			"tags": "Abbot;Antarctica_IMBIE23;WestAntarcticaIMBIE;AbbotIceShelfDrainage",
 			"author": "Xylar Asay-Davis",
-			"object": "region"
+			"component": "iceshelves",
+			"name": "Abbot",
+			"object": "region",
+			"tags": "Abbot;Antarctica_IMBIE23;WestAntarcticaIMBIE;AbbotIceShelfDrainage"
 		 },
 		 "geometry":
 			{"type": "MultiPolygon",

--- a/iceshelves/region/Amery_1/region.geojson
+++ b/iceshelves/region/Amery_1/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Amery_1",
-			"component": "iceshelves",
-			"tags": "Amery;Antarctica_IMBIE9;AmeryIceShelfDrainage;EastAntarcticaIMBIE",
 			"author": "Xylar Asay-Davis",
-			"object": "region"
+			"component": "iceshelves",
+			"name": "Amery_1",
+			"object": "region",
+			"tags": "Amery;Antarctica_IMBIE9;AmeryIceShelfDrainage;EastAntarcticaIMBIE"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/iceshelves/region/Amery_2/region.geojson
+++ b/iceshelves/region/Amery_2/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Amery_2",
-			"component": "iceshelves",
-			"tags": "Amery;Antarctica_IMBIE10;AmeryIceShelfDrainage;EastAntarcticaIMBIE",
 			"author": "Xylar Asay-Davis",
-			"object": "region"
+			"component": "iceshelves",
+			"name": "Amery_2",
+			"object": "region",
+			"tags": "Amery;Antarctica_IMBIE10;AmeryIceShelfDrainage;EastAntarcticaIMBIE"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/iceshelves/region/Amery_3/region.geojson
+++ b/iceshelves/region/Amery_3/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Amery_3",
-			"component": "iceshelves",
-			"tags": "Amery;Antarctica_IMBIE11;AmeryIceShelfDrainage;EastAntarcticaIMBIE",
 			"author": "Xylar Asay-Davis",
-			"object": "region"
+			"component": "iceshelves",
+			"name": "Amery_3",
+			"object": "region",
+			"tags": "Amery;Antarctica_IMBIE11;AmeryIceShelfDrainage;EastAntarcticaIMBIE"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/iceshelves/region/Atka/region.geojson
+++ b/iceshelves/region/Atka/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Atka",
-			"component": "iceshelves",
-			"tags": "Atka;Antarctica_IMBIE5;EastAntarcticaIMBIE",
 			"author": "Xylar Asay-Davis",
-			"object": "region"
+			"component": "iceshelves",
+			"name": "Atka",
+			"object": "region",
+			"tags": "Atka;Antarctica_IMBIE5;EastAntarcticaIMBIE"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/iceshelves/region/Aviator/region.geojson
+++ b/iceshelves/region/Aviator/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Aviator",
-			"component": "iceshelves",
-			"tags": "Aviator;Antarctica_IMBIE15;EastAntarcticaIMBIE",
 			"author": "Xylar Asay-Davis",
-			"object": "region"
+			"component": "iceshelves",
+			"name": "Aviator",
+			"object": "region",
+			"tags": "Aviator;Antarctica_IMBIE15;EastAntarcticaIMBIE"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/iceshelves/region/Bach/region.geojson
+++ b/iceshelves/region/Bach/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Bach",
-			"component": "iceshelves",
-			"tags": "Bach;Antarctica_IMBIE24;AntarcticPenninsulaIMBIE;WilkinsGeorgeVIceShelfDrainage",
 			"author": "Xylar Asay-Davis",
-			"object": "region"
+			"component": "iceshelves",
+			"name": "Bach",
+			"object": "region",
+			"tags": "Bach;Antarctica_IMBIE24;AntarcticPenninsulaIMBIE;WilkinsGeorgeVIceShelfDrainage"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/iceshelves/region/Baudouin/region.geojson
+++ b/iceshelves/region/Baudouin/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Baudouin",
-			"component": "iceshelves",
-			"tags": "Baudouin;Antarctica_IMBIE6;EastAntarcticaIMBIE",
 			"author": "Xylar Asay-Davis",
-			"object": "region"
+			"component": "iceshelves",
+			"name": "Baudouin",
+			"object": "region",
+			"tags": "Baudouin;Antarctica_IMBIE6;EastAntarcticaIMBIE"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/iceshelves/region/Borchgrevink/region.geojson
+++ b/iceshelves/region/Borchgrevink/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Borchgrevink",
-			"component": "iceshelves",
-			"tags": "Borchgrevink;Antarctica_IMBIE6;EastAntarcticaIMBIE",
 			"author": "Xylar Asay-Davis",
-			"object": "region"
+			"component": "iceshelves",
+			"name": "Borchgrevink",
+			"object": "region",
+			"tags": "Borchgrevink;Antarctica_IMBIE6;EastAntarcticaIMBIE"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/iceshelves/region/Brahms/region.geojson
+++ b/iceshelves/region/Brahms/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Brahms",
-			"component": "iceshelves",
-			"tags": "Brahms;Antarctica_IMBIE24;AntarcticPenninsulaIMBIE;WilkinsGeorgeVIceShelfDrainage",
 			"author": "Xylar Asay-Davis",
-			"object": "region"
+			"component": "iceshelves",
+			"name": "Brahms",
+			"object": "region",
+			"tags": "Brahms;Antarctica_IMBIE24;AntarcticPenninsulaIMBIE;WilkinsGeorgeVIceShelfDrainage"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/iceshelves/region/Brunt_Stancomb/region.geojson
+++ b/iceshelves/region/Brunt_Stancomb/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Brunt_Stancomb",
-			"component": "iceshelves",
-			"tags": "Brunt_Stancomb;Antarctica_IMBIE4;EastAntarcticaIMBIE",
 			"author": "Xylar Asay-Davis",
-			"object": "region"
+			"component": "iceshelves",
+			"name": "Brunt_Stancomb",
+			"object": "region",
+			"tags": "Brunt_Stancomb;Antarctica_IMBIE4;EastAntarcticaIMBIE"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/iceshelves/region/Campbell/region.geojson
+++ b/iceshelves/region/Campbell/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Campbell",
-			"component": "iceshelves",
-			"tags": "Campbell;Antarctica_IMBIE16;EastAntarcticaIMBIE",
 			"author": "Xylar Asay-Davis",
-			"object": "region"
+			"component": "iceshelves",
+			"name": "Campbell",
+			"object": "region",
+			"tags": "Campbell;Antarctica_IMBIE16;EastAntarcticaIMBIE"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/iceshelves/region/Cheetham/region.geojson
+++ b/iceshelves/region/Cheetham/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Cheetham",
-			"component": "iceshelves",
-			"tags": "Cheetham;Antarctica_IMBIE16;EastAntarcticaIMBIE",
 			"author": "Xylar Asay-Davis",
-			"object": "region"
+			"component": "iceshelves",
+			"name": "Cheetham",
+			"object": "region",
+			"tags": "Cheetham;Antarctica_IMBIE16;EastAntarcticaIMBIE"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/iceshelves/region/Conger_Glenzer/region.geojson
+++ b/iceshelves/region/Conger_Glenzer/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Conger_Glenzer",
-			"component": "iceshelves",
-			"tags": "Conger_Glenzer;Antarctica_IMBIE12;EastAntarcticaIMBIE",
 			"author": "Xylar Asay-Davis",
-			"object": "region"
+			"component": "iceshelves",
+			"name": "Conger_Glenzer",
+			"object": "region",
+			"tags": "Conger_Glenzer;Antarctica_IMBIE12;EastAntarcticaIMBIE"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/iceshelves/region/Cook/region.geojson
+++ b/iceshelves/region/Cook/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Cook",
-			"component": "iceshelves",
-			"tags": "Cook;Antarctica_IMBIE14;EastAntarcticaIMBIE",
 			"author": "Xylar Asay-Davis",
-			"object": "region"
+			"component": "iceshelves",
+			"name": "Cook",
+			"object": "region",
+			"tags": "Cook;Antarctica_IMBIE14;EastAntarcticaIMBIE"
 		 },
 		 "geometry":
 			{"type": "MultiPolygon",

--- a/iceshelves/region/Cosgrove_1/region.geojson
+++ b/iceshelves/region/Cosgrove_1/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Cosgrove_1",
-			"component": "iceshelves",
-			"tags": "Cosgrove;Antarctica_IMBIE22;PineIslandDrainage;PineIslandThwaitesDrainage;WestAntarcticaIMBIE",
 			"author": "Xylar Asay-Davis",
-			"object": "region"
+			"component": "iceshelves",
+			"name": "Cosgrove_1",
+			"object": "region",
+			"tags": "Cosgrove;Antarctica_IMBIE22;PineIslandDrainage;PineIslandThwaitesDrainage;WestAntarcticaIMBIE"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/iceshelves/region/Cosgrove_2/region.geojson
+++ b/iceshelves/region/Cosgrove_2/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Cosgrove_2",
-			"component": "iceshelves",
-			"tags": "Cosgrove;Antarctica_IMBIE23;WestAntarcticaIMBIE;AbbotIceShelfDrainage",
 			"author": "Xylar Asay-Davis",
-			"object": "region"
+			"component": "iceshelves",
+			"name": "Cosgrove_2",
+			"object": "region",
+			"tags": "Cosgrove;Antarctica_IMBIE23;WestAntarcticaIMBIE;AbbotIceShelfDrainage"
 		 },
 		 "geometry":
 			{"type": "MultiPolygon",

--- a/iceshelves/region/Crosson/region.geojson
+++ b/iceshelves/region/Crosson/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Crosson",
-			"component": "iceshelves",
-			"tags": "Crosson;Antarctica_IMBIE21;ThwaitesDrainage;PineIslandThwaitesDrainage;WestAntarcticaIMBIE",
 			"author": "Xylar Asay-Davis",
-			"object": "region"
+			"component": "iceshelves",
+			"name": "Crosson",
+			"object": "region",
+			"tags": "Crosson;Antarctica_IMBIE21;ThwaitesDrainage;PineIslandThwaitesDrainage;WestAntarcticaIMBIE"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/iceshelves/region/Dennistoun/region.geojson
+++ b/iceshelves/region/Dennistoun/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Dennistoun",
-			"component": "iceshelves",
-			"tags": "Dennistoun;Antarctica_IMBIE15;EastAntarcticaIMBIE",
 			"author": "Xylar Asay-Davis",
-			"object": "region"
+			"component": "iceshelves",
+			"name": "Dennistoun",
+			"object": "region",
+			"tags": "Dennistoun;Antarctica_IMBIE15;EastAntarcticaIMBIE"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/iceshelves/region/Dibble/region.geojson
+++ b/iceshelves/region/Dibble/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Dibble",
-			"component": "iceshelves",
-			"tags": "Dibble;Antarctica_IMBIE14;EastAntarcticaIMBIE",
 			"author": "Xylar Asay-Davis",
-			"object": "region"
+			"component": "iceshelves",
+			"name": "Dibble",
+			"object": "region",
+			"tags": "Dibble;Antarctica_IMBIE14;EastAntarcticaIMBIE"
 		 },
 		 "geometry":
 			{"type": "MultiPolygon",

--- a/iceshelves/region/Dotson/region.geojson
+++ b/iceshelves/region/Dotson/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Dotson",
-			"component": "iceshelves",
-			"tags": "Dotson;Antarctica_IMBIE21;ThwaitesDrainage;PineIslandThwaitesDrainage;WestAntarcticaIMBIE",
 			"author": "Xylar Asay-Davis",
-			"object": "region"
+			"component": "iceshelves",
+			"name": "Dotson",
+			"object": "region",
+			"tags": "Dotson;Antarctica_IMBIE21;ThwaitesDrainage;PineIslandThwaitesDrainage;WestAntarcticaIMBIE"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/iceshelves/region/Drygalski/region.geojson
+++ b/iceshelves/region/Drygalski/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Drygalski",
-			"component": "iceshelves",
-			"tags": "Drygalski;Antarctica_IMBIE16;EastAntarcticaIMBIE",
 			"author": "Xylar Asay-Davis",
-			"object": "region"
+			"component": "iceshelves",
+			"name": "Drygalski",
+			"object": "region",
+			"tags": "Drygalski;Antarctica_IMBIE16;EastAntarcticaIMBIE"
 		 },
 		 "geometry":
 			{"type": "MultiPolygon",

--- a/iceshelves/region/Edward_VIII_1/region.geojson
+++ b/iceshelves/region/Edward_VIII_1/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Edward_VIII_1",
-			"component": "iceshelves",
-			"tags": "Edward_VIII;Antarctica_IMBIE7;EastAntarcticaIMBIE",
 			"author": "Xylar Asay-Davis",
-			"object": "region"
+			"component": "iceshelves",
+			"name": "Edward_VIII_1",
+			"object": "region",
+			"tags": "Edward_VIII;Antarctica_IMBIE7;EastAntarcticaIMBIE"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/iceshelves/region/Edward_VIII_2/region.geojson
+++ b/iceshelves/region/Edward_VIII_2/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Edward_VIII_2",
-			"component": "iceshelves",
-			"tags": "Edward_VIII;Antarctica_IMBIE8;EastAntarcticaIMBIE",
 			"author": "Xylar Asay-Davis",
-			"object": "region"
+			"component": "iceshelves",
+			"name": "Edward_VIII_2",
+			"object": "region",
+			"tags": "Edward_VIII;Antarctica_IMBIE8;EastAntarcticaIMBIE"
 		 },
 		 "geometry":
 			{"type": "MultiPolygon",

--- a/iceshelves/region/Ekstrom/region.geojson
+++ b/iceshelves/region/Ekstrom/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Ekstrom",
-			"component": "iceshelves",
-			"tags": "Ekstrom;Antarctica_IMBIE5;EastAntarcticaIMBIE",
 			"author": "Xylar Asay-Davis",
-			"object": "region"
+			"component": "iceshelves",
+			"name": "Ekstrom",
+			"object": "region",
+			"tags": "Ekstrom;Antarctica_IMBIE5;EastAntarcticaIMBIE"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/iceshelves/region/Ferrigno/region.geojson
+++ b/iceshelves/region/Ferrigno/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Ferrigno",
-			"component": "iceshelves",
-			"tags": "Ferrigno;Antarctica_IMBIE23;WestAntarcticaIMBIE;AbbotIceShelfDrainage",
 			"author": "Xylar Asay-Davis",
-			"object": "region"
+			"component": "iceshelves",
+			"name": "Ferrigno",
+			"object": "region",
+			"tags": "Ferrigno;Antarctica_IMBIE23;WestAntarcticaIMBIE;AbbotIceShelfDrainage"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/iceshelves/region/Filchner_1/region.geojson
+++ b/iceshelves/region/Filchner_1/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Filchner_1",
-			"component": "iceshelves",
-			"tags": "Filchner;Antarctica_IMBIE2;FilchnerRonneIceShelfDrainage;EastAntarcticaIMBIE",
 			"author": "Xylar Asay-Davis",
-			"object": "region"
+			"component": "iceshelves",
+			"name": "Filchner_1",
+			"object": "region",
+			"tags": "Filchner;Antarctica_IMBIE2;FilchnerRonneIceShelfDrainage;EastAntarcticaIMBIE"
 		 },
 		 "geometry":
 			{"type": "MultiPolygon",

--- a/iceshelves/region/Filchner_2/region.geojson
+++ b/iceshelves/region/Filchner_2/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Filchner_2",
-			"component": "iceshelves",
-			"tags": "Filchner;Antarctica_IMBIE3;FilchnerRonneIceShelfDrainage;EastAntarcticaIMBIE",
 			"author": "Xylar Asay-Davis",
-			"object": "region"
+			"component": "iceshelves",
+			"name": "Filchner_2",
+			"object": "region",
+			"tags": "Filchner;Antarctica_IMBIE3;FilchnerRonneIceShelfDrainage;EastAntarcticaIMBIE"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/iceshelves/region/Filchner_3/region.geojson
+++ b/iceshelves/region/Filchner_3/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Filchner_3",
-			"component": "iceshelves",
-			"tags": "Filchner;Antarctica_IMBIE4;EastAntarcticaIMBIE",
 			"author": "Xylar Asay-Davis",
-			"object": "region"
+			"component": "iceshelves",
+			"name": "Filchner_3",
+			"object": "region",
+			"tags": "Filchner;Antarctica_IMBIE4;EastAntarcticaIMBIE"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/iceshelves/region/Fimbul_1/region.geojson
+++ b/iceshelves/region/Fimbul_1/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Fimbul_1",
-			"component": "iceshelves",
-			"tags": "Fimbul;Antarctica_IMBIE5;EastAntarcticaIMBIE",
 			"author": "Xylar Asay-Davis",
-			"object": "region"
+			"component": "iceshelves",
+			"name": "Fimbul_1",
+			"object": "region",
+			"tags": "Fimbul;Antarctica_IMBIE5;EastAntarcticaIMBIE"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/iceshelves/region/Fimbul_2/region.geojson
+++ b/iceshelves/region/Fimbul_2/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Fimbul_2",
-			"component": "iceshelves",
-			"tags": "Fimbul;Antarctica_IMBIE6;EastAntarcticaIMBIE",
 			"author": "Xylar Asay-Davis",
-			"object": "region"
+			"component": "iceshelves",
+			"name": "Fimbul_2",
+			"object": "region",
+			"tags": "Fimbul;Antarctica_IMBIE6;EastAntarcticaIMBIE"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/iceshelves/region/Fitzgerald/region.geojson
+++ b/iceshelves/region/Fitzgerald/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Fitzgerald",
-			"component": "iceshelves",
-			"tags": "Fitzgerald;Antarctica_IMBIE15;EastAntarcticaIMBIE",
 			"author": "Xylar Asay-Davis",
-			"object": "region"
+			"component": "iceshelves",
+			"name": "Fitzgerald",
+			"object": "region",
+			"tags": "Fitzgerald;Antarctica_IMBIE15;EastAntarcticaIMBIE"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/iceshelves/region/Frost_1/region.geojson
+++ b/iceshelves/region/Frost_1/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Frost_1",
-			"component": "iceshelves",
-			"tags": "Frost;Antarctica_IMBIE13;EastAntarcticaIMBIE",
 			"author": "Xylar Asay-Davis",
-			"object": "region"
+			"component": "iceshelves",
+			"name": "Frost_1",
+			"object": "region",
+			"tags": "Frost;Antarctica_IMBIE13;EastAntarcticaIMBIE"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/iceshelves/region/Frost_2/region.geojson
+++ b/iceshelves/region/Frost_2/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Frost_2",
-			"component": "iceshelves",
-			"tags": "Frost;Antarctica_IMBIE14;EastAntarcticaIMBIE",
 			"author": "Xylar Asay-Davis",
-			"object": "region"
+			"component": "iceshelves",
+			"name": "Frost_2",
+			"object": "region",
+			"tags": "Frost;Antarctica_IMBIE14;EastAntarcticaIMBIE"
 		 },
 		 "geometry":
 			{"type": "MultiPolygon",

--- a/iceshelves/region/GeikieInlet/region.geojson
+++ b/iceshelves/region/GeikieInlet/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "GeikieInlet",
-			"component": "iceshelves",
-			"tags": "GeikieInlet;Antarctica_IMBIE16;EastAntarcticaIMBIE",
 			"author": "Xylar Asay-Davis",
-			"object": "region"
+			"component": "iceshelves",
+			"name": "GeikieInlet",
+			"object": "region",
+			"tags": "GeikieInlet;Antarctica_IMBIE16;EastAntarcticaIMBIE"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/iceshelves/region/George_VI/region.geojson
+++ b/iceshelves/region/George_VI/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "George_VI",
-			"component": "iceshelves",
-			"tags": "George_VI;Antarctica_IMBIE24;AntarcticPenninsulaIMBIE;WilkinsGeorgeVIceShelfDrainage",
 			"author": "Xylar Asay-Davis",
-			"object": "region"
+			"component": "iceshelves",
+			"name": "George_VI",
+			"object": "region",
+			"tags": "George_VI;Antarctica_IMBIE24;AntarcticPenninsulaIMBIE;WilkinsGeorgeVIceShelfDrainage"
 		 },
 		 "geometry":
 			{"type": "MultiPolygon",

--- a/iceshelves/region/Getz/region.geojson
+++ b/iceshelves/region/Getz/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Getz",
-			"component": "iceshelves",
-			"tags": "Getz;Antarctica_IMBIE20;GetzIceShelfDrainage;WestAntarcticaIMBIE",
 			"author": "Xylar Asay-Davis",
-			"object": "region"
+			"component": "iceshelves",
+			"name": "Getz",
+			"object": "region",
+			"tags": "Getz;Antarctica_IMBIE20;GetzIceShelfDrainage;WestAntarcticaIMBIE"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/iceshelves/region/Gillet/region.geojson
+++ b/iceshelves/region/Gillet/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Gillet",
-			"component": "iceshelves",
-			"tags": "Gillet;Antarctica_IMBIE15;EastAntarcticaIMBIE",
 			"author": "Xylar Asay-Davis",
-			"object": "region"
+			"component": "iceshelves",
+			"name": "Gillet",
+			"object": "region",
+			"tags": "Gillet;Antarctica_IMBIE15;EastAntarcticaIMBIE"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/iceshelves/region/Hamilton/region.geojson
+++ b/iceshelves/region/Hamilton/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Hamilton",
-			"component": "iceshelves",
-			"tags": "Hamilton;Antarctica_IMBIE20;GetzIceShelfDrainage;WestAntarcticaIMBIE",
 			"author": "Xylar Asay-Davis",
-			"object": "region"
+			"component": "iceshelves",
+			"name": "Hamilton",
+			"object": "region",
+			"tags": "Hamilton;Antarctica_IMBIE20;GetzIceShelfDrainage;WestAntarcticaIMBIE"
 		 },
 		 "geometry":
 			{"type": "MultiPolygon",

--- a/iceshelves/region/Hannan/region.geojson
+++ b/iceshelves/region/Hannan/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Hannan",
-			"component": "iceshelves",
-			"tags": "Hannan;Antarctica_IMBIE7;EastAntarcticaIMBIE",
 			"author": "Xylar Asay-Davis",
-			"object": "region"
+			"component": "iceshelves",
+			"name": "Hannan",
+			"object": "region",
+			"tags": "Hannan;Antarctica_IMBIE7;EastAntarcticaIMBIE"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/iceshelves/region/HarbordGlacier/region.geojson
+++ b/iceshelves/region/HarbordGlacier/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "HarbordGlacier",
-			"component": "iceshelves",
-			"tags": "HarbordGlacier;Antarctica_IMBIE16;EastAntarcticaIMBIE",
 			"author": "Xylar Asay-Davis",
-			"object": "region"
+			"component": "iceshelves",
+			"name": "HarbordGlacier",
+			"object": "region",
+			"tags": "HarbordGlacier;Antarctica_IMBIE16;EastAntarcticaIMBIE"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/iceshelves/region/Helen/region.geojson
+++ b/iceshelves/region/Helen/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Helen",
-			"component": "iceshelves",
-			"tags": "Helen;Antarctica_IMBIE12;EastAntarcticaIMBIE",
 			"author": "Xylar Asay-Davis",
-			"object": "region"
+			"component": "iceshelves",
+			"name": "Helen",
+			"object": "region",
+			"tags": "Helen;Antarctica_IMBIE12;EastAntarcticaIMBIE"
 		 },
 		 "geometry":
 			{"type": "MultiPolygon",

--- a/iceshelves/region/Holmes/region.geojson
+++ b/iceshelves/region/Holmes/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Holmes",
-			"component": "iceshelves",
-			"tags": "Holmes;Antarctica_IMBIE13;EastAntarcticaIMBIE",
 			"author": "Xylar Asay-Davis",
-			"object": "region"
+			"component": "iceshelves",
+			"name": "Holmes",
+			"object": "region",
+			"tags": "Holmes;Antarctica_IMBIE13;EastAntarcticaIMBIE"
 		 },
 		 "geometry":
 			{"type": "MultiPolygon",

--- a/iceshelves/region/HolmesWest/region.geojson
+++ b/iceshelves/region/HolmesWest/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "HolmesWest",
-			"component": "iceshelves",
-			"tags": "HolmesWest;Antarctica_IMBIE13;EastAntarcticaIMBIE",
 			"author": "Xylar Asay-Davis",
-			"object": "region"
+			"component": "iceshelves",
+			"name": "HolmesWest",
+			"object": "region",
+			"tags": "HolmesWest;Antarctica_IMBIE13;EastAntarcticaIMBIE"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/iceshelves/region/Hull/region.geojson
+++ b/iceshelves/region/Hull/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Hull",
-			"component": "iceshelves",
-			"tags": "Hull;Antarctica_IMBIE20;GetzIceShelfDrainage;WestAntarcticaIMBIE",
 			"author": "Xylar Asay-Davis",
-			"object": "region"
+			"component": "iceshelves",
+			"name": "Hull",
+			"object": "region",
+			"tags": "Hull;Antarctica_IMBIE20;GetzIceShelfDrainage;WestAntarcticaIMBIE"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/iceshelves/region/Jelbart/region.geojson
+++ b/iceshelves/region/Jelbart/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Jelbart",
-			"component": "iceshelves",
-			"tags": "Jelbart;Antarctica_IMBIE5;EastAntarcticaIMBIE",
 			"author": "Xylar Asay-Davis",
-			"object": "region"
+			"component": "iceshelves",
+			"name": "Jelbart",
+			"object": "region",
+			"tags": "Jelbart;Antarctica_IMBIE5;EastAntarcticaIMBIE"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/iceshelves/region/Land/region.geojson
+++ b/iceshelves/region/Land/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Land",
-			"component": "iceshelves",
-			"tags": "Land;Antarctica_IMBIE20;GetzIceShelfDrainage;WestAntarcticaIMBIE",
 			"author": "Xylar Asay-Davis",
-			"object": "region"
+			"component": "iceshelves",
+			"name": "Land",
+			"object": "region",
+			"tags": "Land;Antarctica_IMBIE20;GetzIceShelfDrainage;WestAntarcticaIMBIE"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/iceshelves/region/Larsen_B/region.geojson
+++ b/iceshelves/region/Larsen_B/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Larsen_B",
-			"component": "iceshelves",
-			"tags": "Larsen_B;Antarctica_IMBIE26;AntarcticPenninsulaIMBIE;LarsenCIceShelfDrainage",
 			"author": "Xylar Asay-Davis",
-			"object": "region"
+			"component": "iceshelves",
+			"name": "Larsen_B",
+			"object": "region",
+			"tags": "Larsen_B;Antarctica_IMBIE26;AntarcticPenninsulaIMBIE;LarsenCIceShelfDrainage"
 		 },
 		 "geometry":
 			{"type": "MultiPolygon",

--- a/iceshelves/region/Larsen_C_1/region.geojson
+++ b/iceshelves/region/Larsen_C_1/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Larsen_C_1",
-			"component": "iceshelves",
-			"tags": "Larsen_C;Antarctica_IMBIE25;AntarcticPenninsulaIMBIE",
 			"author": "Xylar Asay-Davis",
-			"object": "region"
+			"component": "iceshelves",
+			"name": "Larsen_C_1",
+			"object": "region",
+			"tags": "Larsen_C;Antarctica_IMBIE25;AntarcticPenninsulaIMBIE"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/iceshelves/region/Larsen_C_2/region.geojson
+++ b/iceshelves/region/Larsen_C_2/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Larsen_C_2",
-			"component": "iceshelves",
-			"tags": "Larsen_C;Antarctica_IMBIE26;AntarcticPenninsulaIMBIE;LarsenCIceShelfDrainage",
 			"author": "Xylar Asay-Davis",
-			"object": "region"
+			"component": "iceshelves",
+			"name": "Larsen_C_2",
+			"object": "region",
+			"tags": "Larsen_C;Antarctica_IMBIE26;AntarcticPenninsulaIMBIE;LarsenCIceShelfDrainage"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/iceshelves/region/Larsen_C_3/region.geojson
+++ b/iceshelves/region/Larsen_C_3/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Larsen_C_3",
-			"component": "iceshelves",
-			"tags": "Larsen_C;Antarctica_IMBIE27;AntarcticPenninsulaIMBIE",
 			"author": "Xylar Asay-Davis",
-			"object": "region"
+			"component": "iceshelves",
+			"name": "Larsen_C_3",
+			"object": "region",
+			"tags": "Larsen_C;Antarctica_IMBIE27;AntarcticPenninsulaIMBIE"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/iceshelves/region/Larsen_D/region.geojson
+++ b/iceshelves/region/Larsen_D/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Larsen_D",
-			"component": "iceshelves",
-			"tags": "Larsen_D;Antarctica_IMBIE27;AntarcticPenninsulaIMBIE",
 			"author": "Xylar Asay-Davis",
-			"object": "region"
+			"component": "iceshelves",
+			"name": "Larsen_D",
+			"object": "region",
+			"tags": "Larsen_D;Antarctica_IMBIE27;AntarcticPenninsulaIMBIE"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/iceshelves/region/Larsen_E/region.geojson
+++ b/iceshelves/region/Larsen_E/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Larsen_E",
-			"component": "iceshelves",
-			"tags": "Larsen_E;Antarctica_IMBIE27;AntarcticPenninsulaIMBIE",
 			"author": "Xylar Asay-Davis",
-			"object": "region"
+			"component": "iceshelves",
+			"name": "Larsen_E",
+			"object": "region",
+			"tags": "Larsen_E;Antarctica_IMBIE27;AntarcticPenninsulaIMBIE"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/iceshelves/region/Larsen_F/region.geojson
+++ b/iceshelves/region/Larsen_F/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Larsen_F",
-			"component": "iceshelves",
-			"tags": "Larsen_F;Antarctica_IMBIE27;AntarcticPenninsulaIMBIE",
 			"author": "Xylar Asay-Davis",
-			"object": "region"
+			"component": "iceshelves",
+			"name": "Larsen_F",
+			"object": "region",
+			"tags": "Larsen_F;Antarctica_IMBIE27;AntarcticPenninsulaIMBIE"
 		 },
 		 "geometry":
 			{"type": "MultiPolygon",

--- a/iceshelves/region/Larsen_G/region.geojson
+++ b/iceshelves/region/Larsen_G/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Larsen_G",
-			"component": "iceshelves",
-			"tags": "Larsen_G;Antarctica_IMBIE1;FilchnerRonneIceShelfDrainage;WestAntarcticaIMBIE",
 			"author": "Xylar Asay-Davis",
-			"object": "region"
+			"component": "iceshelves",
+			"name": "Larsen_G",
+			"object": "region",
+			"tags": "Larsen_G;Antarctica_IMBIE1;FilchnerRonneIceShelfDrainage;WestAntarcticaIMBIE"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/iceshelves/region/Lazarev/region.geojson
+++ b/iceshelves/region/Lazarev/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Lazarev",
-			"component": "iceshelves",
-			"tags": "Lazarev;Antarctica_IMBIE6;EastAntarcticaIMBIE",
 			"author": "Xylar Asay-Davis",
-			"object": "region"
+			"component": "iceshelves",
+			"name": "Lazarev",
+			"object": "region",
+			"tags": "Lazarev;Antarctica_IMBIE6;EastAntarcticaIMBIE"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/iceshelves/region/Lillie/region.geojson
+++ b/iceshelves/region/Lillie/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Lillie",
-			"component": "iceshelves",
-			"tags": "Lillie;Antarctica_IMBIE15;EastAntarcticaIMBIE",
 			"author": "Xylar Asay-Davis",
-			"object": "region"
+			"component": "iceshelves",
+			"name": "Lillie",
+			"object": "region",
+			"tags": "Lillie;Antarctica_IMBIE15;EastAntarcticaIMBIE"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/iceshelves/region/Mariner/region.geojson
+++ b/iceshelves/region/Mariner/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Mariner",
-			"component": "iceshelves",
-			"tags": "Mariner;Antarctica_IMBIE15;EastAntarcticaIMBIE",
 			"author": "Xylar Asay-Davis",
-			"object": "region"
+			"component": "iceshelves",
+			"name": "Mariner",
+			"object": "region",
+			"tags": "Mariner;Antarctica_IMBIE15;EastAntarcticaIMBIE"
 		 },
 		 "geometry":
 			{"type": "MultiPolygon",

--- a/iceshelves/region/Matusevitch/region.geojson
+++ b/iceshelves/region/Matusevitch/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Matusevitch",
-			"component": "iceshelves",
-			"tags": "Matusevitch;Antarctica_IMBIE14;EastAntarcticaIMBIE",
 			"author": "Xylar Asay-Davis",
-			"object": "region"
+			"component": "iceshelves",
+			"name": "Matusevitch",
+			"object": "region",
+			"tags": "Matusevitch;Antarctica_IMBIE14;EastAntarcticaIMBIE"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/iceshelves/region/Mendelssohn/region.geojson
+++ b/iceshelves/region/Mendelssohn/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Mendelssohn",
-			"component": "iceshelves",
-			"tags": "Mendelssohn;Antarctica_IMBIE24;AntarcticPenninsulaIMBIE;WilkinsGeorgeVIceShelfDrainage",
 			"author": "Xylar Asay-Davis",
-			"object": "region"
+			"component": "iceshelves",
+			"name": "Mendelssohn",
+			"object": "region",
+			"tags": "Mendelssohn;Antarctica_IMBIE24;AntarcticPenninsulaIMBIE;WilkinsGeorgeVIceShelfDrainage"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/iceshelves/region/Mertz/region.geojson
+++ b/iceshelves/region/Mertz/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Mertz",
-			"component": "iceshelves",
-			"tags": "Mertz;Antarctica_IMBIE14;EastAntarcticaIMBIE",
 			"author": "Xylar Asay-Davis",
-			"object": "region"
+			"component": "iceshelves",
+			"name": "Mertz",
+			"object": "region",
+			"tags": "Mertz;Antarctica_IMBIE14;EastAntarcticaIMBIE"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/iceshelves/region/Moscow_University/region.geojson
+++ b/iceshelves/region/Moscow_University/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Moscow_University",
-			"component": "iceshelves",
-			"tags": "Moscow_University;Antarctica_IMBIE13;EastAntarcticaIMBIE",
 			"author": "Xylar Asay-Davis",
-			"object": "region"
+			"component": "iceshelves",
+			"name": "Moscow_University",
+			"object": "region",
+			"tags": "Moscow_University;Antarctica_IMBIE13;EastAntarcticaIMBIE"
 		 },
 		 "geometry":
 			{"type": "MultiPolygon",

--- a/iceshelves/region/Moubray/region.geojson
+++ b/iceshelves/region/Moubray/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Moubray",
-			"component": "iceshelves",
-			"tags": "Moubray;Antarctica_IMBIE15;EastAntarcticaIMBIE",
 			"author": "Xylar Asay-Davis",
-			"object": "region"
+			"component": "iceshelves",
+			"name": "Moubray",
+			"object": "region",
+			"tags": "Moubray;Antarctica_IMBIE15;EastAntarcticaIMBIE"
 		 },
 		 "geometry":
 			{"type": "MultiPolygon",

--- a/iceshelves/region/Mulebreen/region.geojson
+++ b/iceshelves/region/Mulebreen/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Mulebreen",
-			"component": "iceshelves",
-			"tags": "Mulebreen;Antarctica_IMBIE8;EastAntarcticaIMBIE",
 			"author": "Xylar Asay-Davis",
-			"object": "region"
+			"component": "iceshelves",
+			"name": "Mulebreen",
+			"object": "region",
+			"tags": "Mulebreen;Antarctica_IMBIE8;EastAntarcticaIMBIE"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/iceshelves/region/Myers/region.geojson
+++ b/iceshelves/region/Myers/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Myers",
-			"component": "iceshelves",
-			"tags": "Myers;Antarctica_IMBIE7;EastAntarcticaIMBIE",
 			"author": "Xylar Asay-Davis",
-			"object": "region"
+			"component": "iceshelves",
+			"name": "Myers",
+			"object": "region",
+			"tags": "Myers;Antarctica_IMBIE7;EastAntarcticaIMBIE"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/iceshelves/region/Nansen/region.geojson
+++ b/iceshelves/region/Nansen/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Nansen",
-			"component": "iceshelves",
-			"tags": "Nansen;Antarctica_IMBIE16;EastAntarcticaIMBIE",
 			"author": "Xylar Asay-Davis",
-			"object": "region"
+			"component": "iceshelves",
+			"name": "Nansen",
+			"object": "region",
+			"tags": "Nansen;Antarctica_IMBIE16;EastAntarcticaIMBIE"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/iceshelves/region/Nickerson/region.geojson
+++ b/iceshelves/region/Nickerson/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Nickerson",
-			"component": "iceshelves",
-			"tags": "Nickerson;Antarctica_IMBIE20;GetzIceShelfDrainage;WestAntarcticaIMBIE",
 			"author": "Xylar Asay-Davis",
-			"object": "region"
+			"component": "iceshelves",
+			"name": "Nickerson",
+			"object": "region",
+			"tags": "Nickerson;Antarctica_IMBIE20;GetzIceShelfDrainage;WestAntarcticaIMBIE"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/iceshelves/region/Ninnis/region.geojson
+++ b/iceshelves/region/Ninnis/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Ninnis",
-			"component": "iceshelves",
-			"tags": "Ninnis;Antarctica_IMBIE14;EastAntarcticaIMBIE",
 			"author": "Xylar Asay-Davis",
-			"object": "region"
+			"component": "iceshelves",
+			"name": "Ninnis",
+			"object": "region",
+			"tags": "Ninnis;Antarctica_IMBIE14;EastAntarcticaIMBIE"
 		 },
 		 "geometry":
 			{"type": "MultiPolygon",

--- a/iceshelves/region/Nivl/region.geojson
+++ b/iceshelves/region/Nivl/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Nivl",
-			"component": "iceshelves",
-			"tags": "Nivl;Antarctica_IMBIE6;EastAntarcticaIMBIE",
 			"author": "Xylar Asay-Davis",
-			"object": "region"
+			"component": "iceshelves",
+			"name": "Nivl",
+			"object": "region",
+			"tags": "Nivl;Antarctica_IMBIE6;EastAntarcticaIMBIE"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/iceshelves/region/Noll/region.geojson
+++ b/iceshelves/region/Noll/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Noll",
-			"component": "iceshelves",
-			"tags": "Noll;Antarctica_IMBIE15;EastAntarcticaIMBIE",
 			"author": "Xylar Asay-Davis",
-			"object": "region"
+			"component": "iceshelves",
+			"name": "Noll",
+			"object": "region",
+			"tags": "Noll;Antarctica_IMBIE15;EastAntarcticaIMBIE"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/iceshelves/region/Nordenskjold/region.geojson
+++ b/iceshelves/region/Nordenskjold/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Nordenskjold",
-			"component": "iceshelves",
-			"tags": "Nordenskjold;Antarctica_IMBIE16;EastAntarcticaIMBIE",
 			"author": "Xylar Asay-Davis",
-			"object": "region"
+			"component": "iceshelves",
+			"name": "Nordenskjold",
+			"object": "region",
+			"tags": "Nordenskjold;Antarctica_IMBIE16;EastAntarcticaIMBIE"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/iceshelves/region/Pine_Island/region.geojson
+++ b/iceshelves/region/Pine_Island/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Pine_Island",
-			"component": "iceshelves",
-			"tags": "Pine_Island;Antarctica_IMBIE22;PineIslandDrainage;PineIslandThwaitesDrainage;WestAntarcticaIMBIE",
 			"author": "Xylar Asay-Davis",
-			"object": "region"
+			"component": "iceshelves",
+			"name": "Pine_Island",
+			"object": "region",
+			"tags": "Pine_Island;Antarctica_IMBIE22;PineIslandDrainage;PineIslandThwaitesDrainage;WestAntarcticaIMBIE"
 		 },
 		 "geometry":
 			{"type": "MultiPolygon",

--- a/iceshelves/region/PourquoiPas/region.geojson
+++ b/iceshelves/region/PourquoiPas/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "PourquoiPas",
-			"component": "iceshelves",
-			"tags": "PourquoiPas;Antarctica_IMBIE14;EastAntarcticaIMBIE",
 			"author": "Xylar Asay-Davis",
-			"object": "region"
+			"component": "iceshelves",
+			"name": "PourquoiPas",
+			"object": "region",
+			"tags": "PourquoiPas;Antarctica_IMBIE14;EastAntarcticaIMBIE"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/iceshelves/region/Prince_Harald/region.geojson
+++ b/iceshelves/region/Prince_Harald/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Prince_Harald",
-			"component": "iceshelves",
-			"tags": "Prince_Harald;Antarctica_IMBIE7;EastAntarcticaIMBIE",
 			"author": "Xylar Asay-Davis",
-			"object": "region"
+			"component": "iceshelves",
+			"name": "Prince_Harald",
+			"object": "region",
+			"tags": "Prince_Harald;Antarctica_IMBIE7;EastAntarcticaIMBIE"
 		 },
 		 "geometry":
 			{"type": "MultiPolygon",

--- a/iceshelves/region/Publications/region.geojson
+++ b/iceshelves/region/Publications/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Publications",
-			"component": "iceshelves",
-			"tags": "Publications;Antarctica_IMBIE12;EastAntarcticaIMBIE",
 			"author": "Xylar Asay-Davis",
-			"object": "region"
+			"component": "iceshelves",
+			"name": "Publications",
+			"object": "region",
+			"tags": "Publications;Antarctica_IMBIE12;EastAntarcticaIMBIE"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/iceshelves/region/Quar/region.geojson
+++ b/iceshelves/region/Quar/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Quar",
-			"component": "iceshelves",
-			"tags": "Quar;Antarctica_IMBIE4;EastAntarcticaIMBIE",
 			"author": "Xylar Asay-Davis",
-			"object": "region"
+			"component": "iceshelves",
+			"name": "Quar",
+			"object": "region",
+			"tags": "Quar;Antarctica_IMBIE4;EastAntarcticaIMBIE"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/iceshelves/region/Rayner_Thyer/region.geojson
+++ b/iceshelves/region/Rayner_Thyer/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Rayner_Thyer",
-			"component": "iceshelves",
-			"tags": "Rayner_Thyer;Antarctica_IMBIE7;EastAntarcticaIMBIE",
 			"author": "Xylar Asay-Davis",
-			"object": "region"
+			"component": "iceshelves",
+			"name": "Rayner_Thyer",
+			"object": "region",
+			"tags": "Rayner_Thyer;Antarctica_IMBIE7;EastAntarcticaIMBIE"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/iceshelves/region/Rennick/region.geojson
+++ b/iceshelves/region/Rennick/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Rennick",
-			"component": "iceshelves",
-			"tags": "Rennick;Antarctica_IMBIE15;EastAntarcticaIMBIE",
 			"author": "Xylar Asay-Davis",
-			"object": "region"
+			"component": "iceshelves",
+			"name": "Rennick",
+			"object": "region",
+			"tags": "Rennick;Antarctica_IMBIE15;EastAntarcticaIMBIE"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/iceshelves/region/Richter/region.geojson
+++ b/iceshelves/region/Richter/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Richter",
-			"component": "iceshelves",
-			"tags": "Richter;Antarctica_IMBIE20;GetzIceShelfDrainage;WestAntarcticaIMBIE",
 			"author": "Xylar Asay-Davis",
-			"object": "region"
+			"component": "iceshelves",
+			"name": "Richter",
+			"object": "region",
+			"tags": "Richter;Antarctica_IMBIE20;GetzIceShelfDrainage;WestAntarcticaIMBIE"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/iceshelves/region/Riiser-Larsen/region.geojson
+++ b/iceshelves/region/Riiser-Larsen/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Riiser-Larsen",
-			"component": "iceshelves",
-			"tags": "Riiser-Larsen;Antarctica_IMBIE4;EastAntarcticaIMBIE",
 			"author": "Xylar Asay-Davis",
-			"object": "region"
+			"component": "iceshelves",
+			"name": "Riiser-Larsen",
+			"object": "region",
+			"tags": "Riiser-Larsen;Antarctica_IMBIE4;EastAntarcticaIMBIE"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/iceshelves/region/Ronne_1/region.geojson
+++ b/iceshelves/region/Ronne_1/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Ronne_1",
-			"component": "iceshelves",
-			"tags": "Ronne;Antarctica_IMBIE1;FilchnerRonneIceShelfDrainage;WestAntarcticaIMBIE",
 			"author": "Xylar Asay-Davis",
-			"object": "region"
+			"component": "iceshelves",
+			"name": "Ronne_1",
+			"object": "region",
+			"tags": "Ronne;Antarctica_IMBIE1;FilchnerRonneIceShelfDrainage;WestAntarcticaIMBIE"
 		 },
 		 "geometry":
 			{"type": "MultiPolygon",

--- a/iceshelves/region/Ronne_2/region.geojson
+++ b/iceshelves/region/Ronne_2/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Ronne_2",
-			"component": "iceshelves",
-			"tags": "Ronne;Antarctica_IMBIE2;FilchnerRonneIceShelfDrainage;EastAntarcticaIMBIE",
 			"author": "Xylar Asay-Davis",
-			"object": "region"
+			"component": "iceshelves",
+			"name": "Ronne_2",
+			"object": "region",
+			"tags": "Ronne;Antarctica_IMBIE2;FilchnerRonneIceShelfDrainage;EastAntarcticaIMBIE"
 		 },
 		 "geometry":
 			{"type": "MultiPolygon",

--- a/iceshelves/region/Ross_East_1/region.geojson
+++ b/iceshelves/region/Ross_East_1/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Ross_East_1",
-			"component": "iceshelves",
-			"tags": "Ross_East;Antarctica_IMBIE16;EastAntarcticaIMBIE",
 			"author": "Xylar Asay-Davis",
-			"object": "region"
+			"component": "iceshelves",
+			"name": "Ross_East_1",
+			"object": "region",
+			"tags": "Ross_East;Antarctica_IMBIE16;EastAntarcticaIMBIE"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/iceshelves/region/Ross_East_2/region.geojson
+++ b/iceshelves/region/Ross_East_2/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Ross_East_2",
-			"component": "iceshelves",
-			"tags": "Ross_East;Antarctica_IMBIE17;RossIceShelfDrainage;EastAntarcticaIMBIE",
 			"author": "Xylar Asay-Davis",
-			"object": "region"
+			"component": "iceshelves",
+			"name": "Ross_East_2",
+			"object": "region",
+			"tags": "Ross_East;Antarctica_IMBIE17;RossIceShelfDrainage;EastAntarcticaIMBIE"
 		 },
 		 "geometry":
 			{"type": "MultiPolygon",

--- a/iceshelves/region/Ross_West_1/region.geojson
+++ b/iceshelves/region/Ross_West_1/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Ross_West_1",
-			"component": "iceshelves",
-			"tags": "Ross_West;Antarctica_IMBIE17;RossIceShelfDrainage;EastAntarcticaIMBIE",
 			"author": "Xylar Asay-Davis",
-			"object": "region"
+			"component": "iceshelves",
+			"name": "Ross_West_1",
+			"object": "region",
+			"tags": "Ross_West;Antarctica_IMBIE17;RossIceShelfDrainage;EastAntarcticaIMBIE"
 		 },
 		 "geometry":
 			{"type": "MultiPolygon",

--- a/iceshelves/region/Ross_West_2/region.geojson
+++ b/iceshelves/region/Ross_West_2/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Ross_West_2",
-			"component": "iceshelves",
-			"tags": "Ross_West;Antarctica_IMBIE18;RossIceShelfDrainage;WestAntarcticaIMBIE",
 			"author": "Xylar Asay-Davis",
-			"object": "region"
+			"component": "iceshelves",
+			"name": "Ross_West_2",
+			"object": "region",
+			"tags": "Ross_West;Antarctica_IMBIE18;RossIceShelfDrainage;WestAntarcticaIMBIE"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/iceshelves/region/Ross_West_3/region.geojson
+++ b/iceshelves/region/Ross_West_3/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Ross_West_3",
-			"component": "iceshelves",
-			"tags": "Ross_West;Antarctica_IMBIE19;RossIceShelfDrainage;WestAntarcticaIMBIE",
 			"author": "Xylar Asay-Davis",
-			"object": "region"
+			"component": "iceshelves",
+			"name": "Ross_West_3",
+			"object": "region",
+			"tags": "Ross_West;Antarctica_IMBIE19;RossIceShelfDrainage;WestAntarcticaIMBIE"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/iceshelves/region/Shackleton/region.geojson
+++ b/iceshelves/region/Shackleton/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Shackleton",
-			"component": "iceshelves",
-			"tags": "Shackleton;Antarctica_IMBIE12;EastAntarcticaIMBIE",
 			"author": "Xylar Asay-Davis",
-			"object": "region"
+			"component": "iceshelves",
+			"name": "Shackleton",
+			"object": "region",
+			"tags": "Shackleton;Antarctica_IMBIE12;EastAntarcticaIMBIE"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/iceshelves/region/Shirase/region.geojson
+++ b/iceshelves/region/Shirase/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Shirase",
-			"component": "iceshelves",
-			"tags": "Shirase;Antarctica_IMBIE7;EastAntarcticaIMBIE",
 			"author": "Xylar Asay-Davis",
-			"object": "region"
+			"component": "iceshelves",
+			"name": "Shirase",
+			"object": "region",
+			"tags": "Shirase;Antarctica_IMBIE7;EastAntarcticaIMBIE"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/iceshelves/region/Slava/region.geojson
+++ b/iceshelves/region/Slava/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Slava",
-			"component": "iceshelves",
-			"tags": "Slava;Antarctica_IMBIE14;EastAntarcticaIMBIE",
 			"author": "Xylar Asay-Davis",
-			"object": "region"
+			"component": "iceshelves",
+			"name": "Slava",
+			"object": "region",
+			"tags": "Slava;Antarctica_IMBIE14;EastAntarcticaIMBIE"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/iceshelves/region/SmithInlet/region.geojson
+++ b/iceshelves/region/SmithInlet/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "SmithInlet",
-			"component": "iceshelves",
-			"tags": "SmithInlet;Antarctica_IMBIE15;EastAntarcticaIMBIE",
 			"author": "Xylar Asay-Davis",
-			"object": "region"
+			"component": "iceshelves",
+			"name": "SmithInlet",
+			"object": "region",
+			"tags": "SmithInlet;Antarctica_IMBIE15;EastAntarcticaIMBIE"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/iceshelves/region/Stange_1/region.geojson
+++ b/iceshelves/region/Stange_1/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Stange_1",
-			"component": "iceshelves",
-			"tags": "Stange;Antarctica_IMBIE23;WestAntarcticaIMBIE;AbbotIceShelfDrainage",
 			"author": "Xylar Asay-Davis",
-			"object": "region"
+			"component": "iceshelves",
+			"name": "Stange_1",
+			"object": "region",
+			"tags": "Stange;Antarctica_IMBIE23;WestAntarcticaIMBIE;AbbotIceShelfDrainage"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/iceshelves/region/Stange_2/region.geojson
+++ b/iceshelves/region/Stange_2/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Stange_2",
-			"component": "iceshelves",
-			"tags": "Stange;Antarctica_IMBIE24;AntarcticPenninsulaIMBIE;WilkinsGeorgeVIceShelfDrainage",
 			"author": "Xylar Asay-Davis",
-			"object": "region"
+			"component": "iceshelves",
+			"name": "Stange_2",
+			"object": "region",
+			"tags": "Stange;Antarctica_IMBIE24;AntarcticPenninsulaIMBIE;WilkinsGeorgeVIceShelfDrainage"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/iceshelves/region/Sulzberger/region.geojson
+++ b/iceshelves/region/Sulzberger/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Sulzberger",
-			"component": "iceshelves",
-			"tags": "Sulzberger;Antarctica_IMBIE20;GetzIceShelfDrainage;WestAntarcticaIMBIE",
 			"author": "Xylar Asay-Davis",
-			"object": "region"
+			"component": "iceshelves",
+			"name": "Sulzberger",
+			"object": "region",
+			"tags": "Sulzberger;Antarctica_IMBIE20;GetzIceShelfDrainage;WestAntarcticaIMBIE"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/iceshelves/region/Suvorov/region.geojson
+++ b/iceshelves/region/Suvorov/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Suvorov",
-			"component": "iceshelves",
-			"tags": "Suvorov;Antarctica_IMBIE15;EastAntarcticaIMBIE",
 			"author": "Xylar Asay-Davis",
-			"object": "region"
+			"component": "iceshelves",
+			"name": "Suvorov",
+			"object": "region",
+			"tags": "Suvorov;Antarctica_IMBIE15;EastAntarcticaIMBIE"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/iceshelves/region/Swinburne/region.geojson
+++ b/iceshelves/region/Swinburne/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Swinburne",
-			"component": "iceshelves",
-			"tags": "Swinburne;Antarctica_IMBIE20;GetzIceShelfDrainage;WestAntarcticaIMBIE",
 			"author": "Xylar Asay-Davis",
-			"object": "region"
+			"component": "iceshelves",
+			"name": "Swinburne",
+			"object": "region",
+			"tags": "Swinburne;Antarctica_IMBIE20;GetzIceShelfDrainage;WestAntarcticaIMBIE"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/iceshelves/region/Thwaites/region.geojson
+++ b/iceshelves/region/Thwaites/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Thwaites",
-			"component": "iceshelves",
-			"tags": "Thwaites;Antarctica_IMBIE21;ThwaitesDrainage;PineIslandThwaitesDrainage;WestAntarcticaIMBIE",
 			"author": "Xylar Asay-Davis",
-			"object": "region"
+			"component": "iceshelves",
+			"name": "Thwaites",
+			"object": "region",
+			"tags": "Thwaites;Antarctica_IMBIE21;ThwaitesDrainage;PineIslandThwaitesDrainage;WestAntarcticaIMBIE"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/iceshelves/region/Tinker/region.geojson
+++ b/iceshelves/region/Tinker/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Tinker",
-			"component": "iceshelves",
-			"tags": "Tinker;Antarctica_IMBIE16;EastAntarcticaIMBIE",
 			"author": "Xylar Asay-Davis",
-			"object": "region"
+			"component": "iceshelves",
+			"name": "Tinker",
+			"object": "region",
+			"tags": "Tinker;Antarctica_IMBIE16;EastAntarcticaIMBIE"
 		 },
 		 "geometry":
 			{"type": "MultiPolygon",

--- a/iceshelves/region/Totten/region.geojson
+++ b/iceshelves/region/Totten/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Totten",
-			"component": "iceshelves",
-			"tags": "Totten;Antarctica_IMBIE13;EastAntarcticaIMBIE",
 			"author": "Xylar Asay-Davis",
-			"object": "region"
+			"component": "iceshelves",
+			"name": "Totten",
+			"object": "region",
+			"tags": "Totten;Antarctica_IMBIE13;EastAntarcticaIMBIE"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/iceshelves/region/Tracy_Tremenchus/region.geojson
+++ b/iceshelves/region/Tracy_Tremenchus/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Tracy_Tremenchus",
-			"component": "iceshelves",
-			"tags": "Tracy_Tremenchus;Antarctica_IMBIE12;EastAntarcticaIMBIE",
 			"author": "Xylar Asay-Davis",
-			"object": "region"
+			"component": "iceshelves",
+			"name": "Tracy_Tremenchus",
+			"object": "region",
+			"tags": "Tracy_Tremenchus;Antarctica_IMBIE12;EastAntarcticaIMBIE"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/iceshelves/region/Tucker/region.geojson
+++ b/iceshelves/region/Tucker/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Tucker",
-			"component": "iceshelves",
-			"tags": "Tucker;Antarctica_IMBIE15;EastAntarcticaIMBIE",
 			"author": "Xylar Asay-Davis",
-			"object": "region"
+			"component": "iceshelves",
+			"name": "Tucker",
+			"object": "region",
+			"tags": "Tucker;Antarctica_IMBIE15;EastAntarcticaIMBIE"
 		 },
 		 "geometry":
 			{"type": "MultiPolygon",

--- a/iceshelves/region/Underwood/region.geojson
+++ b/iceshelves/region/Underwood/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Underwood",
-			"component": "iceshelves",
-			"tags": "Underwood;Antarctica_IMBIE13;EastAntarcticaIMBIE",
 			"author": "Xylar Asay-Davis",
-			"object": "region"
+			"component": "iceshelves",
+			"name": "Underwood",
+			"object": "region",
+			"tags": "Underwood;Antarctica_IMBIE13;EastAntarcticaIMBIE"
 		 },
 		 "geometry":
 			{"type": "MultiPolygon",

--- a/iceshelves/region/Utsikkar/region.geojson
+++ b/iceshelves/region/Utsikkar/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Utsikkar",
-			"component": "iceshelves",
-			"tags": "Utsikkar;Antarctica_IMBIE8;EastAntarcticaIMBIE",
 			"author": "Xylar Asay-Davis",
-			"object": "region"
+			"component": "iceshelves",
+			"name": "Utsikkar",
+			"object": "region",
+			"tags": "Utsikkar;Antarctica_IMBIE8;EastAntarcticaIMBIE"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/iceshelves/region/Venable/region.geojson
+++ b/iceshelves/region/Venable/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Venable",
-			"component": "iceshelves",
-			"tags": "Venable;Antarctica_IMBIE23;WestAntarcticaIMBIE;AbbotIceShelfDrainage",
 			"author": "Xylar Asay-Davis",
-			"object": "region"
+			"component": "iceshelves",
+			"name": "Venable",
+			"object": "region",
+			"tags": "Venable;Antarctica_IMBIE23;WestAntarcticaIMBIE;AbbotIceShelfDrainage"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/iceshelves/region/Verdi/region.geojson
+++ b/iceshelves/region/Verdi/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Verdi",
-			"component": "iceshelves",
-			"tags": "Verdi;Antarctica_IMBIE24;AntarcticPenninsulaIMBIE;WilkinsGeorgeVIceShelfDrainage",
 			"author": "Xylar Asay-Davis",
-			"object": "region"
+			"component": "iceshelves",
+			"name": "Verdi",
+			"object": "region",
+			"tags": "Verdi;Antarctica_IMBIE24;AntarcticPenninsulaIMBIE;WilkinsGeorgeVIceShelfDrainage"
 		 },
 		 "geometry":
 			{"type": "MultiPolygon",

--- a/iceshelves/region/Vigrid/region.geojson
+++ b/iceshelves/region/Vigrid/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Vigrid",
-			"component": "iceshelves",
-			"tags": "Vigrid;Antarctica_IMBIE6;EastAntarcticaIMBIE",
 			"author": "Xylar Asay-Davis",
-			"object": "region"
+			"component": "iceshelves",
+			"name": "Vigrid",
+			"object": "region",
+			"tags": "Vigrid;Antarctica_IMBIE6;EastAntarcticaIMBIE"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/iceshelves/region/Vincennes/region.geojson
+++ b/iceshelves/region/Vincennes/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Vincennes",
-			"component": "iceshelves",
-			"tags": "Vincennes;Antarctica_IMBIE13;EastAntarcticaIMBIE",
 			"author": "Xylar Asay-Davis",
-			"object": "region"
+			"component": "iceshelves",
+			"name": "Vincennes",
+			"object": "region",
+			"tags": "Vincennes;Antarctica_IMBIE13;EastAntarcticaIMBIE"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/iceshelves/region/Voyeykov/region.geojson
+++ b/iceshelves/region/Voyeykov/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Voyeykov",
-			"component": "iceshelves",
-			"tags": "Voyeykov;Antarctica_IMBIE13;EastAntarcticaIMBIE",
 			"author": "Xylar Asay-Davis",
-			"object": "region"
+			"component": "iceshelves",
+			"name": "Voyeykov",
+			"object": "region",
+			"tags": "Voyeykov;Antarctica_IMBIE13;EastAntarcticaIMBIE"
 		 },
 		 "geometry":
 			{"type": "MultiPolygon",

--- a/iceshelves/region/West/region.geojson
+++ b/iceshelves/region/West/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "West",
-			"component": "iceshelves",
-			"tags": "West;Antarctica_IMBIE12;EastAntarcticaIMBIE",
 			"author": "Xylar Asay-Davis",
-			"object": "region"
+			"component": "iceshelves",
+			"name": "West",
+			"object": "region",
+			"tags": "West;Antarctica_IMBIE12;EastAntarcticaIMBIE"
 		 },
 		 "geometry":
 			{"type": "MultiPolygon",

--- a/iceshelves/region/Wilkins/region.geojson
+++ b/iceshelves/region/Wilkins/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Wilkins",
-			"component": "iceshelves",
-			"tags": "Wilkins;Antarctica_IMBIE24;AntarcticPenninsulaIMBIE;WilkinsGeorgeVIceShelfDrainage",
 			"author": "Xylar Asay-Davis",
-			"object": "region"
+			"component": "iceshelves",
+			"name": "Wilkins",
+			"object": "region",
+			"tags": "Wilkins;Antarctica_IMBIE24;AntarcticPenninsulaIMBIE;WilkinsGeorgeVIceShelfDrainage"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/iceshelves/region/Wilma_Robert_Downer/region.geojson
+++ b/iceshelves/region/Wilma_Robert_Downer/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Wilma_Robert_Downer",
-			"component": "iceshelves",
-			"tags": "Wilma_Robert_Downer;Antarctica_IMBIE8;EastAntarcticaIMBIE",
 			"author": "Xylar Asay-Davis",
-			"object": "region"
+			"component": "iceshelves",
+			"name": "Wilma_Robert_Downer",
+			"object": "region",
+			"tags": "Wilma_Robert_Downer;Antarctica_IMBIE8;EastAntarcticaIMBIE"
 		 },
 		 "geometry":
 			{"type": "MultiPolygon",

--- a/iceshelves/region/Withrow/region.geojson
+++ b/iceshelves/region/Withrow/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Withrow",
-			"component": "iceshelves",
-			"tags": "Withrow;Antarctica_IMBIE20;GetzIceShelfDrainage;WestAntarcticaIMBIE",
 			"author": "Xylar Asay-Davis",
-			"object": "region"
+			"component": "iceshelves",
+			"name": "Withrow",
+			"object": "region",
+			"tags": "Withrow;Antarctica_IMBIE20;GetzIceShelfDrainage;WestAntarcticaIMBIE"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/iceshelves/region/Wordie/region.geojson
+++ b/iceshelves/region/Wordie/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Wordie",
-			"component": "iceshelves",
-			"tags": "Wordie;Antarctica_IMBIE25;AntarcticPenninsulaIMBIE",
 			"author": "Xylar Asay-Davis",
-			"object": "region"
+			"component": "iceshelves",
+			"name": "Wordie",
+			"object": "region",
+			"tags": "Wordie;Antarctica_IMBIE25;AntarcticPenninsulaIMBIE"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/iceshelves/region/Wylde/region.geojson
+++ b/iceshelves/region/Wylde/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Wylde",
-			"component": "iceshelves",
-			"tags": "Wylde;Antarctica_IMBIE15;EastAntarcticaIMBIE",
 			"author": "Xylar Asay-Davis",
-			"object": "region"
+			"component": "iceshelves",
+			"name": "Wylde",
+			"object": "region",
+			"tags": "Wylde;Antarctica_IMBIE15;EastAntarcticaIMBIE"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/iceshelves/region/Zubchatyy/region.geojson
+++ b/iceshelves/region/Zubchatyy/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Zubchatyy",
-			"component": "iceshelves",
-			"tags": "Zubchatyy;Antarctica_IMBIE7;EastAntarcticaIMBIE",
 			"author": "Xylar Asay-Davis",
-			"object": "region"
+			"component": "iceshelves",
+			"name": "Zubchatyy",
+			"object": "region",
+			"tags": "Zubchatyy;Antarctica_IMBIE7;EastAntarcticaIMBIE"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/landice/region/Antarctica_IMBIE1/region.geojson
+++ b/landice/region/Antarctica_IMBIE1/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Antarctica_IMBIE1",
-			"component": "landice",
-			"tags": "FilchnerRonneIceShelfDrainage;WestAntarcticaIMBIE",
 			"author": "http://icesat4.gsfc.nasa.gov/cryo_data/ant_grn_drainage_systems.php",
-			"object": "region"
+			"component": "landice",
+			"name": "Antarctica_IMBIE1",
+			"object": "region",
+			"tags": "FilchnerRonneIceShelfDrainage;WestAntarcticaIMBIE"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/landice/region/Antarctica_IMBIE10/region.geojson
+++ b/landice/region/Antarctica_IMBIE10/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Antarctica_IMBIE10",
-			"component": "landice",
-			"tags": "AmeryIceShelfDrainage;EastAntarcticaIMBIE",
 			"author": "http://icesat4.gsfc.nasa.gov/cryo_data/ant_grn_drainage_systems.php",
-			"object": "region"
+			"component": "landice",
+			"name": "Antarctica_IMBIE10",
+			"object": "region",
+			"tags": "AmeryIceShelfDrainage;EastAntarcticaIMBIE"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/landice/region/Antarctica_IMBIE11/region.geojson
+++ b/landice/region/Antarctica_IMBIE11/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Antarctica_IMBIE11",
-			"component": "landice",
-			"tags": "AmeryIceShelfDrainage;EastAntarcticaIMBIE",
 			"author": "http://icesat4.gsfc.nasa.gov/cryo_data/ant_grn_drainage_systems.php",
-			"object": "region"
+			"component": "landice",
+			"name": "Antarctica_IMBIE11",
+			"object": "region",
+			"tags": "AmeryIceShelfDrainage;EastAntarcticaIMBIE"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/landice/region/Antarctica_IMBIE12/region.geojson
+++ b/landice/region/Antarctica_IMBIE12/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Antarctica_IMBIE12",
-			"component": "landice",
-			"tags": "EastAntarcticaIMBIE",
 			"author": "http://icesat4.gsfc.nasa.gov/cryo_data/ant_grn_drainage_systems.php",
-			"object": "region"
+			"component": "landice",
+			"name": "Antarctica_IMBIE12",
+			"object": "region",
+			"tags": "EastAntarcticaIMBIE"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/landice/region/Antarctica_IMBIE13/region.geojson
+++ b/landice/region/Antarctica_IMBIE13/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Antarctica_IMBIE13",
-			"component": "landice",
-			"tags": "EastAntarcticaIMBIE",
 			"author": "http://icesat4.gsfc.nasa.gov/cryo_data/ant_grn_drainage_systems.php",
-			"object": "region"
+			"component": "landice",
+			"name": "Antarctica_IMBIE13",
+			"object": "region",
+			"tags": "EastAntarcticaIMBIE"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/landice/region/Antarctica_IMBIE14/region.geojson
+++ b/landice/region/Antarctica_IMBIE14/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Antarctica_IMBIE14",
-			"component": "landice",
-			"tags": "EastAntarcticaIMBIE",
 			"author": "http://icesat4.gsfc.nasa.gov/cryo_data/ant_grn_drainage_systems.php",
-			"object": "region"
+			"component": "landice",
+			"name": "Antarctica_IMBIE14",
+			"object": "region",
+			"tags": "EastAntarcticaIMBIE"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/landice/region/Antarctica_IMBIE15/region.geojson
+++ b/landice/region/Antarctica_IMBIE15/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Antarctica_IMBIE15",
-			"component": "landice",
-			"tags": "EastAntarcticaIMBIE",
 			"author": "http://icesat4.gsfc.nasa.gov/cryo_data/ant_grn_drainage_systems.php",
-			"object": "region"
+			"component": "landice",
+			"name": "Antarctica_IMBIE15",
+			"object": "region",
+			"tags": "EastAntarcticaIMBIE"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/landice/region/Antarctica_IMBIE16/region.geojson
+++ b/landice/region/Antarctica_IMBIE16/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Antarctica_IMBIE16",
-			"component": "landice",
-			"tags": "EastAntarcticaIMBIE",
 			"author": "http://icesat4.gsfc.nasa.gov/cryo_data/ant_grn_drainage_systems.php",
-			"object": "region"
+			"component": "landice",
+			"name": "Antarctica_IMBIE16",
+			"object": "region",
+			"tags": "EastAntarcticaIMBIE"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/landice/region/Antarctica_IMBIE17/region.geojson
+++ b/landice/region/Antarctica_IMBIE17/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Antarctica_IMBIE17",
-			"component": "landice",
-			"tags": "RossIceShelfDrainage;EastAntarcticaIMBIE",
 			"author": "http://icesat4.gsfc.nasa.gov/cryo_data/ant_grn_drainage_systems.php",
-			"object": "region"
+			"component": "landice",
+			"name": "Antarctica_IMBIE17",
+			"object": "region",
+			"tags": "RossIceShelfDrainage;EastAntarcticaIMBIE"
 		 },
 		 "geometry":
 			{"type": "MultiPolygon",

--- a/landice/region/Antarctica_IMBIE18/region.geojson
+++ b/landice/region/Antarctica_IMBIE18/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Antarctica_IMBIE18",
-			"component": "landice",
-			"tags": "RossIceShelfDrainage;WestAntarcticaIMBIE",
 			"author": "http://icesat4.gsfc.nasa.gov/cryo_data/ant_grn_drainage_systems.php",
-			"object": "region"
+			"component": "landice",
+			"name": "Antarctica_IMBIE18",
+			"object": "region",
+			"tags": "RossIceShelfDrainage;WestAntarcticaIMBIE"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/landice/region/Antarctica_IMBIE19/region.geojson
+++ b/landice/region/Antarctica_IMBIE19/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Antarctica_IMBIE19",
-			"component": "landice",
-			"tags": "RossIceShelfDrainage;WestAntarcticaIMBIE",
 			"author": "http://icesat4.gsfc.nasa.gov/cryo_data/ant_grn_drainage_systems.php",
-			"object": "region"
+			"component": "landice",
+			"name": "Antarctica_IMBIE19",
+			"object": "region",
+			"tags": "RossIceShelfDrainage;WestAntarcticaIMBIE"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/landice/region/Antarctica_IMBIE2/region.geojson
+++ b/landice/region/Antarctica_IMBIE2/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Antarctica_IMBIE2",
-			"component": "landice",
-			"tags": "FilchnerRonneIceShelfDrainage;EastAntarcticaIMBIE",
 			"author": "http://icesat4.gsfc.nasa.gov/cryo_data/ant_grn_drainage_systems.php",
-			"object": "region"
+			"component": "landice",
+			"name": "Antarctica_IMBIE2",
+			"object": "region",
+			"tags": "FilchnerRonneIceShelfDrainage;EastAntarcticaIMBIE"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/landice/region/Antarctica_IMBIE20/region.geojson
+++ b/landice/region/Antarctica_IMBIE20/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Antarctica_IMBIE20",
-			"component": "landice",
-			"tags": "GetzIceShelfDrainage;WestAntarcticaIMBIE",
 			"author": "http://icesat4.gsfc.nasa.gov/cryo_data/ant_grn_drainage_systems.php",
-			"object": "region"
+			"component": "landice",
+			"name": "Antarctica_IMBIE20",
+			"object": "region",
+			"tags": "GetzIceShelfDrainage;WestAntarcticaIMBIE"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/landice/region/Antarctica_IMBIE21/region.geojson
+++ b/landice/region/Antarctica_IMBIE21/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Antarctica_IMBIE21",
-			"component": "landice",
-			"tags": "ThwaitesDrainage;PineIslandThwaitesDrainage;WestAntarcticaIMBIE",
 			"author": "http://icesat4.gsfc.nasa.gov/cryo_data/ant_grn_drainage_systems.php",
-			"object": "region"
+			"component": "landice",
+			"name": "Antarctica_IMBIE21",
+			"object": "region",
+			"tags": "ThwaitesDrainage;PineIslandThwaitesDrainage;WestAntarcticaIMBIE"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/landice/region/Antarctica_IMBIE22/region.geojson
+++ b/landice/region/Antarctica_IMBIE22/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Antarctica_IMBIE22",
-			"component": "landice",
-			"tags": "PineIslandDrainage;PineIslandThwaitesDrainage;WestAntarcticaIMBIE",
 			"author": "http://icesat4.gsfc.nasa.gov/cryo_data/ant_grn_drainage_systems.php",
-			"object": "region"
+			"component": "landice",
+			"name": "Antarctica_IMBIE22",
+			"object": "region",
+			"tags": "PineIslandDrainage;PineIslandThwaitesDrainage;WestAntarcticaIMBIE"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/landice/region/Antarctica_IMBIE23/region.geojson
+++ b/landice/region/Antarctica_IMBIE23/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Antarctica_IMBIE23",
-			"component": "landice",
-			"tags": "WestAntarcticaIMBIE;AbbotIceShelfDrainage",
 			"author": "http://icesat4.gsfc.nasa.gov/cryo_data/ant_grn_drainage_systems.php",
-			"object": "region"
+			"component": "landice",
+			"name": "Antarctica_IMBIE23",
+			"object": "region",
+			"tags": "WestAntarcticaIMBIE;AbbotIceShelfDrainage"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/landice/region/Antarctica_IMBIE24/region.geojson
+++ b/landice/region/Antarctica_IMBIE24/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Antarctica_IMBIE24",
-			"component": "landice",
-			"tags": "WilkinsGeorgeVIceShelfDrainage;AntarcticPeninsulaIMBIE",
 			"author": "http://icesat4.gsfc.nasa.gov/cryo_data/ant_grn_drainage_systems.php",
-			"object": "region"
+			"component": "landice",
+			"name": "Antarctica_IMBIE24",
+			"object": "region",
+			"tags": "WilkinsGeorgeVIceShelfDrainage;AntarcticPeninsulaIMBIE"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/landice/region/Antarctica_IMBIE25/region.geojson
+++ b/landice/region/Antarctica_IMBIE25/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Antarctica_IMBIE25",
-			"component": "landice",
-			"tags": "AntarcticPeninsulaIMBIE",
 			"author": "http://icesat4.gsfc.nasa.gov/cryo_data/ant_grn_drainage_systems.php",
-			"object": "region"
+			"component": "landice",
+			"name": "Antarctica_IMBIE25",
+			"object": "region",
+			"tags": "AntarcticPeninsulaIMBIE"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/landice/region/Antarctica_IMBIE26/region.geojson
+++ b/landice/region/Antarctica_IMBIE26/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Antarctica_IMBIE26",
-			"component": "landice",
-			"tags": "LarsenCIceShelfDrainage;AntarcticPeninsulaIMBIE",
 			"author": "http://icesat4.gsfc.nasa.gov/cryo_data/ant_grn_drainage_systems.php",
-			"object": "region"
+			"component": "landice",
+			"name": "Antarctica_IMBIE26",
+			"object": "region",
+			"tags": "LarsenCIceShelfDrainage;AntarcticPeninsulaIMBIE"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/landice/region/Antarctica_IMBIE27/region.geojson
+++ b/landice/region/Antarctica_IMBIE27/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Antarctica_IMBIE27",
-			"component": "landice",
-			"tags": "AntarcticPeninsulaIMBIE",
 			"author": "http://icesat4.gsfc.nasa.gov/cryo_data/ant_grn_drainage_systems.php",
-			"object": "region"
+			"component": "landice",
+			"name": "Antarctica_IMBIE27",
+			"object": "region",
+			"tags": "AntarcticPeninsulaIMBIE"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/landice/region/Antarctica_IMBIE3/region.geojson
+++ b/landice/region/Antarctica_IMBIE3/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Antarctica_IMBIE3",
-			"component": "landice",
-			"tags": "FilchnerRonneIceShelfDrainage;EastAntarcticaIMBIE",
 			"author": "http://icesat4.gsfc.nasa.gov/cryo_data/ant_grn_drainage_systems.php",
-			"object": "region"
+			"component": "landice",
+			"name": "Antarctica_IMBIE3",
+			"object": "region",
+			"tags": "FilchnerRonneIceShelfDrainage;EastAntarcticaIMBIE"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/landice/region/Antarctica_IMBIE4/region.geojson
+++ b/landice/region/Antarctica_IMBIE4/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Antarctica_IMBIE4",
-			"component": "landice",
-			"tags": "EastAntarcticaIMBIE",
 			"author": "http://icesat4.gsfc.nasa.gov/cryo_data/ant_grn_drainage_systems.php",
-			"object": "region"
+			"component": "landice",
+			"name": "Antarctica_IMBIE4",
+			"object": "region",
+			"tags": "EastAntarcticaIMBIE"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/landice/region/Antarctica_IMBIE5/region.geojson
+++ b/landice/region/Antarctica_IMBIE5/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Antarctica_IMBIE5",
-			"component": "landice",
-			"tags": "EastAntarcticaIMBIE",
 			"author": "http://icesat4.gsfc.nasa.gov/cryo_data/ant_grn_drainage_systems.php",
-			"object": "region"
+			"component": "landice",
+			"name": "Antarctica_IMBIE5",
+			"object": "region",
+			"tags": "EastAntarcticaIMBIE"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/landice/region/Antarctica_IMBIE6/region.geojson
+++ b/landice/region/Antarctica_IMBIE6/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Antarctica_IMBIE6",
-			"component": "landice",
-			"tags": "EastAntarcticaIMBIE",
 			"author": "http://icesat4.gsfc.nasa.gov/cryo_data/ant_grn_drainage_systems.php",
-			"object": "region"
+			"component": "landice",
+			"name": "Antarctica_IMBIE6",
+			"object": "region",
+			"tags": "EastAntarcticaIMBIE"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/landice/region/Antarctica_IMBIE7/region.geojson
+++ b/landice/region/Antarctica_IMBIE7/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Antarctica_IMBIE7",
-			"component": "landice",
-			"tags": "EastAntarcticaIMBIE",
 			"author": "http://icesat4.gsfc.nasa.gov/cryo_data/ant_grn_drainage_systems.php",
-			"object": "region"
+			"component": "landice",
+			"name": "Antarctica_IMBIE7",
+			"object": "region",
+			"tags": "EastAntarcticaIMBIE"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/landice/region/Antarctica_IMBIE8/region.geojson
+++ b/landice/region/Antarctica_IMBIE8/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Antarctica_IMBIE8",
-			"component": "landice",
-			"tags": "EastAntarcticaIMBIE",
 			"author": "http://icesat4.gsfc.nasa.gov/cryo_data/ant_grn_drainage_systems.php",
-			"object": "region"
+			"component": "landice",
+			"name": "Antarctica_IMBIE8",
+			"object": "region",
+			"tags": "EastAntarcticaIMBIE"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/landice/region/Antarctica_IMBIE9/region.geojson
+++ b/landice/region/Antarctica_IMBIE9/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Antarctica_IMBIE9",
-			"component": "landice",
-			"tags": "AmeryIceShelfDrainage;EastAntarcticaIMBIE",
 			"author": "http://icesat4.gsfc.nasa.gov/cryo_data/ant_grn_drainage_systems.php",
-			"object": "region"
+			"component": "landice",
+			"name": "Antarctica_IMBIE9",
+			"object": "region",
+			"tags": "AmeryIceShelfDrainage;EastAntarcticaIMBIE"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/landice/region/eastCentralGreenland1/region.geojson
+++ b/landice/region/eastCentralGreenland1/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "eastCentralGreenland1",
-			"component": "landice",
-			"tags": "eastCentralGreenland",
 			"author": "http://icesat4.gsfc.nasa.gov/cryo_data/ant_grn_drainage_systems.php",
-			"object": "region"
+			"component": "landice",
+			"name": "eastCentralGreenland1",
+			"object": "region",
+			"tags": "eastCentralGreenland"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/landice/region/eastCentralGreenland2/region.geojson
+++ b/landice/region/eastCentralGreenland2/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "eastCentralGreenland2",
-			"component": "landice",
-			"tags": "eastCentralGreenland",
 			"author": "http://icesat4.gsfc.nasa.gov/cryo_data/ant_grn_drainage_systems.php",
-			"object": "region"
+			"component": "landice",
+			"name": "eastCentralGreenland2",
+			"object": "region",
+			"tags": "eastCentralGreenland"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/landice/region/eastCentralGreenland3/region.geojson
+++ b/landice/region/eastCentralGreenland3/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "eastCentralGreenland3",
-			"component": "landice",
-			"tags": "eastCentralGreenland",
 			"author": "http://icesat4.gsfc.nasa.gov/cryo_data/ant_grn_drainage_systems.php",
-			"object": "region"
+			"component": "landice",
+			"name": "eastCentralGreenland3",
+			"object": "region",
+			"tags": "eastCentralGreenland"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/landice/region/northEastGreenland1/region.geojson
+++ b/landice/region/northEastGreenland1/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "northEastGreenland1",
-			"component": "landice",
-			"tags": "northEastGreenland",
 			"author": "http://icesat4.gsfc.nasa.gov/cryo_data/ant_grn_drainage_systems.php",
-			"object": "region"
+			"component": "landice",
+			"name": "northEastGreenland1",
+			"object": "region",
+			"tags": "northEastGreenland"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/landice/region/northEastGreenland2/region.geojson
+++ b/landice/region/northEastGreenland2/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "northEastGreenland2",
-			"component": "landice",
-			"tags": "northEastGreenland",
 			"author": "http://icesat4.gsfc.nasa.gov/cryo_data/ant_grn_drainage_systems.php",
-			"object": "region"
+			"component": "landice",
+			"name": "northEastGreenland2",
+			"object": "region",
+			"tags": "northEastGreenland"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/landice/region/northGreenland1/region.geojson
+++ b/landice/region/northGreenland1/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "northGreenland1",
-			"component": "landice",
-			"tags": "northGreenland",
 			"author": "http://icesat4.gsfc.nasa.gov/cryo_data/ant_grn_drainage_systems.php",
-			"object": "region"
+			"component": "landice",
+			"name": "northGreenland1",
+			"object": "region",
+			"tags": "northGreenland"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/landice/region/northGreenland2/region.geojson
+++ b/landice/region/northGreenland2/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "northGreenland2",
-			"component": "landice",
-			"tags": "northGreenland",
 			"author": "http://icesat4.gsfc.nasa.gov/cryo_data/ant_grn_drainage_systems.php",
-			"object": "region"
+			"component": "landice",
+			"name": "northGreenland2",
+			"object": "region",
+			"tags": "northGreenland"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/landice/region/northGreenland3/region.geojson
+++ b/landice/region/northGreenland3/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "northGreenland3",
-			"component": "landice",
-			"tags": "northGreenland",
 			"author": "http://icesat4.gsfc.nasa.gov/cryo_data/ant_grn_drainage_systems.php",
-			"object": "region"
+			"component": "landice",
+			"name": "northGreenland3",
+			"object": "region",
+			"tags": "northGreenland"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/landice/region/northGreenland4/region.geojson
+++ b/landice/region/northGreenland4/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "northGreenland4",
-			"component": "landice",
-			"tags": "northGreenland",
 			"author": "http://icesat4.gsfc.nasa.gov/cryo_data/ant_grn_drainage_systems.php",
-			"object": "region"
+			"component": "landice",
+			"name": "northGreenland4",
+			"object": "region",
+			"tags": "northGreenland"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/landice/region/northWestGreenland1/region.geojson
+++ b/landice/region/northWestGreenland1/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "northWestGreenland1",
-			"component": "landice",
-			"tags": "northWestGreenland",
 			"author": "http://icesat4.gsfc.nasa.gov/cryo_data/ant_grn_drainage_systems.php",
-			"object": "region"
+			"component": "landice",
+			"name": "northWestGreenland1",
+			"object": "region",
+			"tags": "northWestGreenland"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/landice/region/northWestGreenland2/region.geojson
+++ b/landice/region/northWestGreenland2/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "northWestGreenland2",
-			"component": "landice",
-			"tags": "northWestGreenland",
 			"author": "http://icesat4.gsfc.nasa.gov/cryo_data/ant_grn_drainage_systems.php",
-			"object": "region"
+			"component": "landice",
+			"name": "northWestGreenland2",
+			"object": "region",
+			"tags": "northWestGreenland"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/landice/region/southEastGreenland1/region.geojson
+++ b/landice/region/southEastGreenland1/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "southEastGreenland1",
-			"component": "landice",
-			"tags": "southEastGreenland",
 			"author": "http://icesat4.gsfc.nasa.gov/cryo_data/ant_grn_drainage_systems.php",
-			"object": "region"
+			"component": "landice",
+			"name": "southEastGreenland1",
+			"object": "region",
+			"tags": "southEastGreenland"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/landice/region/southEastGreenland2/region.geojson
+++ b/landice/region/southEastGreenland2/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "southEastGreenland2",
-			"component": "landice",
-			"tags": "southEastGreenland",
 			"author": "http://icesat4.gsfc.nasa.gov/cryo_data/ant_grn_drainage_systems.php",
-			"object": "region"
+			"component": "landice",
+			"name": "southEastGreenland2",
+			"object": "region",
+			"tags": "southEastGreenland"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/landice/region/southEastGreenland3/region.geojson
+++ b/landice/region/southEastGreenland3/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "southEastGreenland3",
-			"component": "landice",
-			"tags": "southEastGreenland",
 			"author": "http://icesat4.gsfc.nasa.gov/cryo_data/ant_grn_drainage_systems.php",
-			"object": "region"
+			"component": "landice",
+			"name": "southEastGreenland3",
+			"object": "region",
+			"tags": "southEastGreenland"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/landice/region/southGreenland1/region.geojson
+++ b/landice/region/southGreenland1/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "southGreenland1",
-			"component": "landice",
-			"tags": "southGreenland",
 			"author": "http://icesat4.gsfc.nasa.gov/cryo_data/ant_grn_drainage_systems.php",
-			"object": "region"
+			"component": "landice",
+			"name": "southGreenland1",
+			"object": "region",
+			"tags": "southGreenland"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/landice/region/southWestGreenland1/region.geojson
+++ b/landice/region/southWestGreenland1/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "southWestGreenland1",
-			"component": "landice",
-			"tags": "southWestGreenland",
 			"author": "http://icesat4.gsfc.nasa.gov/cryo_data/ant_grn_drainage_systems.php",
-			"object": "region"
+			"component": "landice",
+			"name": "southWestGreenland1",
+			"object": "region",
+			"tags": "southWestGreenland"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/landice/region/southWestGreenland2/region.geojson
+++ b/landice/region/southWestGreenland2/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "southWestGreenland2",
-			"component": "landice",
-			"tags": "southWestGreenland",
 			"author": "http://icesat4.gsfc.nasa.gov/cryo_data/ant_grn_drainage_systems.php",
-			"object": "region"
+			"component": "landice",
+			"name": "southWestGreenland2",
+			"object": "region",
+			"tags": "southWestGreenland"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/landice/region/westCentralGreenland1/region.geojson
+++ b/landice/region/westCentralGreenland1/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "westCentralGreenland1",
-			"component": "landice",
-			"tags": "westCentralGreenland",
 			"author": "http://icesat4.gsfc.nasa.gov/cryo_data/ant_grn_drainage_systems.php",
-			"object": "region"
+			"component": "landice",
+			"name": "westCentralGreenland1",
+			"object": "region",
+			"tags": "westCentralGreenland"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/landice/region/westCentralGreenland2/region.geojson
+++ b/landice/region/westCentralGreenland2/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "westCentralGreenland2",
-			"component": "landice",
-			"tags": "westCentralGreenland",
 			"author": "http://icesat4.gsfc.nasa.gov/cryo_data/ant_grn_drainage_systems.php",
-			"object": "region"
+			"component": "landice",
+			"name": "westCentralGreenland2",
+			"object": "region",
+			"tags": "westCentralGreenland"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/ocean/region/Adriatic_Sea/region.geojson
+++ b/ocean/region/Adriatic_Sea/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Adriatic Sea",
-			"component": "ocean",
-			"tags": "Adriatic_Sea;Mediterranean_Basin",
 			"author": "http://www.marineregions.org/downloads.php#iho",
-			"object": "region"
+			"component": "ocean",
+			"name": "Adriatic Sea",
+			"object": "region",
+			"tags": "Adriatic_Sea;Mediterranean_Basin"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/ocean/region/Aegean_Sea/region.geojson
+++ b/ocean/region/Aegean_Sea/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Aegean Sea",
-			"component": "ocean",
-			"tags": "Aegean_Sea;Mediterranean_Basin",
 			"author": "http://www.marineregions.org/downloads.php#iho",
-			"object": "region"
+			"component": "ocean",
+			"name": "Aegean Sea",
+			"object": "region",
+			"tags": "Aegean_Sea;Mediterranean_Basin"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/ocean/region/Alboran_Sea/region.geojson
+++ b/ocean/region/Alboran_Sea/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Alboran Sea",
-			"component": "ocean",
-			"tags": "Alboran_Sea;Mediterranean_Basin",
 			"author": "http://www.marineregions.org/downloads.php#iho",
-			"object": "region"
+			"component": "ocean",
+			"name": "Alboran Sea",
+			"object": "region",
+			"tags": "Alboran_Sea;Mediterranean_Basin"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/ocean/region/Andaman_or_Burma_Sea/region.geojson
+++ b/ocean/region/Andaman_or_Burma_Sea/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Andaman or Burma Sea",
-			"component": "ocean",
-			"tags": "Andaman_or_Burma_Sea;Indian_Basin",
 			"author": "http://www.marineregions.org/downloads.php#iho",
-			"object": "region"
+			"component": "ocean",
+			"name": "Andaman or Burma Sea",
+			"object": "region",
+			"tags": "Andaman_or_Burma_Sea;Indian_Basin"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/ocean/region/Arabian_Sea/region.geojson
+++ b/ocean/region/Arabian_Sea/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Arabian Sea",
-			"component": "ocean",
-			"tags": "Arabian_Sea;Indian_Basin",
 			"author": "http://www.marineregions.org/downloads.php#iho",
-			"object": "region"
+			"component": "ocean",
+			"name": "Arabian Sea",
+			"object": "region",
+			"tags": "Arabian_Sea;Indian_Basin"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/ocean/region/Arafura_Sea/region.geojson
+++ b/ocean/region/Arafura_Sea/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Arafura Sea",
-			"component": "ocean",
-			"tags": "Arafura_Sea;Pacific_Basin",
 			"author": "http://www.marineregions.org/downloads.php#iho",
-			"object": "region"
+			"component": "ocean",
+			"name": "Arafura Sea",
+			"object": "region",
+			"tags": "Arafura_Sea;Pacific_Basin"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/ocean/region/Arctic_Ocean/region.geojson
+++ b/ocean/region/Arctic_Ocean/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Arctic Ocean",
-			"component": "ocean",
-			"tags": "Arctic_Ocean;Arctic_Basin",
 			"author": "http://www.marineregions.org/downloads.php#iho",
-			"object": "region"
+			"component": "ocean",
+			"name": "Arctic Ocean",
+			"object": "region",
+			"tags": "Arctic_Ocean;Arctic_Basin"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/ocean/region/Baffin_Bay/region.geojson
+++ b/ocean/region/Baffin_Bay/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Baffin Bay",
-			"component": "ocean",
-			"tags": "Baffin_Bay;Atlantic_Basin",
 			"author": "http://www.marineregions.org/downloads.php#iho",
-			"object": "region"
+			"component": "ocean",
+			"name": "Baffin Bay",
+			"object": "region",
+			"tags": "Baffin_Bay;Atlantic_Basin"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/ocean/region/Balearic_Sea/region.geojson
+++ b/ocean/region/Balearic_Sea/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Balearic Sea",
-			"component": "ocean",
-			"tags": "Balearic_Sea;Mediterranean_Basin",
 			"author": "http://www.marineregions.org/downloads.php#iho",
-			"object": "region"
+			"component": "ocean",
+			"name": "Balearic Sea",
+			"object": "region",
+			"tags": "Balearic_Sea;Mediterranean_Basin"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/ocean/region/Bali_Sea/region.geojson
+++ b/ocean/region/Bali_Sea/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Bali Sea",
-			"component": "ocean",
-			"tags": "Bali_Sea;Pacific_Basin",
 			"author": "http://www.marineregions.org/downloads.php#iho",
-			"object": "region"
+			"component": "ocean",
+			"name": "Bali Sea",
+			"object": "region",
+			"tags": "Bali_Sea;Pacific_Basin"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/ocean/region/Baltic_Sea/region.geojson
+++ b/ocean/region/Baltic_Sea/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Baltic Sea",
-			"component": "ocean",
-			"tags": "Baltic_Sea;Atlantic_Basin",
 			"author": "http://www.marineregions.org/downloads.php#iho",
-			"object": "region"
+			"component": "ocean",
+			"name": "Baltic Sea",
+			"object": "region",
+			"tags": "Baltic_Sea;Atlantic_Basin"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/ocean/region/Banda_Sea/region.geojson
+++ b/ocean/region/Banda_Sea/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Banda Sea",
-			"component": "ocean",
-			"tags": "Banda_Sea;Pacific_Basin",
 			"author": "http://www.marineregions.org/downloads.php#iho",
-			"object": "region"
+			"component": "ocean",
+			"name": "Banda Sea",
+			"object": "region",
+			"tags": "Banda_Sea;Pacific_Basin"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/ocean/region/Barentsz_Sea/region.geojson
+++ b/ocean/region/Barentsz_Sea/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Barentsz Sea",
-			"component": "ocean",
-			"tags": "Barentsz_Sea;Arctic_Basin",
 			"author": "http://www.marineregions.org/downloads.php#iho",
-			"object": "region"
+			"component": "ocean",
+			"name": "Barentsz Sea",
+			"object": "region",
+			"tags": "Barentsz_Sea;Arctic_Basin"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/ocean/region/Bass_Strait_North/region.geojson
+++ b/ocean/region/Bass_Strait_North/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Bass Strait North",
-			"component": "ocean",
-			"tags": "Bass_Strait;Indian_Basin",
 			"author": "http://www.marineregions.org/downloads.php#iho",
-			"object": "region"
+			"component": "ocean",
+			"name": "Bass Strait North",
+			"object": "region",
+			"tags": "Bass_Strait;Indian_Basin"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/ocean/region/Bass_Strait_South/region.geojson
+++ b/ocean/region/Bass_Strait_South/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Bass Strait South",
-			"component": "ocean",
-			"tags": "Bass_Strait;Southern_Ocean_Basin",
 			"author": "http://www.marineregions.org/downloads.php#iho",
-			"object": "region"
+			"component": "ocean",
+			"name": "Bass Strait South",
+			"object": "region",
+			"tags": "Bass_Strait;Southern_Ocean_Basin"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/ocean/region/Bay_of_Bengal/region.geojson
+++ b/ocean/region/Bay_of_Bengal/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Bay of Bengal",
-			"component": "ocean",
-			"tags": "Bay_of_Bengal;Indian_Basin",
 			"author": "http://www.marineregions.org/downloads.php#iho",
-			"object": "region"
+			"component": "ocean",
+			"name": "Bay of Bengal",
+			"object": "region",
+			"tags": "Bay_of_Bengal;Indian_Basin"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/ocean/region/Bay_of_Biscay/region.geojson
+++ b/ocean/region/Bay_of_Biscay/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Bay of Biscay",
-			"component": "ocean",
-			"tags": "Bay_of_Biscay;Atlantic_Basin",
 			"author": "http://www.marineregions.org/downloads.php#iho",
-			"object": "region"
+			"component": "ocean",
+			"name": "Bay of Biscay",
+			"object": "region",
+			"tags": "Bay_of_Biscay;Atlantic_Basin"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/ocean/region/Bay_of_Fundy/region.geojson
+++ b/ocean/region/Bay_of_Fundy/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Bay of Fundy",
-			"component": "ocean",
-			"tags": "Bay_of_Fundy;Atlantic_Basin",
 			"author": "http://www.marineregions.org/downloads.php#iho",
-			"object": "region"
+			"component": "ocean",
+			"name": "Bay of Fundy",
+			"object": "region",
+			"tags": "Bay_of_Fundy;Atlantic_Basin"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/ocean/region/Beaufort_Sea/region.geojson
+++ b/ocean/region/Beaufort_Sea/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Beaufort Sea",
-			"component": "ocean",
-			"tags": "Beaufort_Sea;Arctic_Basin",
 			"author": "http://www.marineregions.org/downloads.php#iho",
-			"object": "region"
+			"component": "ocean",
+			"name": "Beaufort Sea",
+			"object": "region",
+			"tags": "Beaufort_Sea;Arctic_Basin"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/ocean/region/Bering_Sea/region.geojson
+++ b/ocean/region/Bering_Sea/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Bering Sea",
-			"component": "ocean",
-			"tags": "Bering_Sea;Pacific_Basin",
 			"author": "http://www.marineregions.org/downloads.php#iho",
-			"object": "region"
+			"component": "ocean",
+			"name": "Bering Sea",
+			"object": "region",
+			"tags": "Bering_Sea;Pacific_Basin"
 		 },
 		 "geometry":
 			{"type": "MultiPolygon",

--- a/ocean/region/Bismarck_Sea/region.geojson
+++ b/ocean/region/Bismarck_Sea/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Bismarck Sea",
-			"component": "ocean",
-			"tags": "Bismarck_Sea;Pacific_Basin",
 			"author": "http://www.marineregions.org/downloads.php#iho",
-			"object": "region"
+			"component": "ocean",
+			"name": "Bismarck Sea",
+			"object": "region",
+			"tags": "Bismarck_Sea;Pacific_Basin"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/ocean/region/Black_Sea/region.geojson
+++ b/ocean/region/Black_Sea/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Black Sea",
-			"component": "ocean",
-			"tags": "Black_Sea",
 			"author": "http://www.marineregions.org/downloads.php#iho",
-			"object": "region"
+			"component": "ocean",
+			"name": "Black Sea",
+			"object": "region",
+			"tags": "Black_Sea"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/ocean/region/Bristol_Channel/region.geojson
+++ b/ocean/region/Bristol_Channel/region.geojson
@@ -1,14 +1,13 @@
 {"type": "FeatureCollection",
- "groupName": "enterNameHere",
  "features":
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Bristol Channel",
-			"component": "ocean",
-			"tags": "Bristol_Channel;Atlantic_Basin",
 			"author": "http://www.marineregions.org/downloads.php#iho",
-			"object": "region"
+			"component": "ocean",
+			"name": "Bristol Channel",
+			"object": "region",
+			"tags": "Bristol_Channel;Atlantic_Basin"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/ocean/region/Caribbean_Sea/region.geojson
+++ b/ocean/region/Caribbean_Sea/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Caribbean Sea",
-			"component": "ocean",
-			"tags": "Caribbean_Sea;Atlantic_Basin",
 			"author": "http://www.marineregions.org/downloads.php#iho",
-			"object": "region"
+			"component": "ocean",
+			"name": "Caribbean Sea",
+			"object": "region",
+			"tags": "Caribbean_Sea;Atlantic_Basin"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/ocean/region/Celebes_Sea/region.geojson
+++ b/ocean/region/Celebes_Sea/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Celebes Sea",
-			"component": "ocean",
-			"tags": "Celebes_Sea;Pacific_Basin",
 			"author": "http://www.marineregions.org/downloads.php#iho",
-			"object": "region"
+			"component": "ocean",
+			"name": "Celebes Sea",
+			"object": "region",
+			"tags": "Celebes_Sea;Pacific_Basin"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/ocean/region/Celtic_Sea/region.geojson
+++ b/ocean/region/Celtic_Sea/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Celtic Sea",
-			"component": "ocean",
-			"tags": "Celtic_Sea;Atlantic_Basin",
 			"author": "http://www.marineregions.org/downloads.php#iho",
-			"object": "region"
+			"component": "ocean",
+			"name": "Celtic Sea",
+			"object": "region",
+			"tags": "Celtic_Sea;Atlantic_Basin"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/ocean/region/Ceram_Sea/region.geojson
+++ b/ocean/region/Ceram_Sea/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Ceram Sea",
-			"component": "ocean",
-			"tags": "Ceram_Sea;Pacific_Basin",
 			"author": "http://www.marineregions.org/downloads.php#iho",
-			"object": "region"
+			"component": "ocean",
+			"name": "Ceram Sea",
+			"object": "region",
+			"tags": "Ceram_Sea;Pacific_Basin"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/ocean/region/Chukchi_Sea/region.geojson
+++ b/ocean/region/Chukchi_Sea/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Chukchi Sea",
-			"component": "ocean",
-			"tags": "Chukchi_Sea;Arctic_Basin",
 			"author": "http://www.marineregions.org/downloads.php#iho",
-			"object": "region"
+			"component": "ocean",
+			"name": "Chukchi Sea",
+			"object": "region",
+			"tags": "Chukchi_Sea;Arctic_Basin"
 		 },
 		 "geometry":
 			{"type": "MultiPolygon",

--- a/ocean/region/Coral_Sea/region.geojson
+++ b/ocean/region/Coral_Sea/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Coral Sea",
-			"component": "ocean",
-			"tags": "Coral_Sea;Pacific_Basin",
 			"author": "http://www.marineregions.org/downloads.php#iho",
-			"object": "region"
+			"component": "ocean",
+			"name": "Coral Sea",
+			"object": "region",
+			"tags": "Coral_Sea;Pacific_Basin"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/ocean/region/Davis_Strait/region.geojson
+++ b/ocean/region/Davis_Strait/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Davis Strait",
-			"component": "ocean",
-			"tags": "Davis_Strait;Atlantic_Basin",
 			"author": "http://www.marineregions.org/downloads.php#iho",
-			"object": "region"
+			"component": "ocean",
+			"name": "Davis Strait",
+			"object": "region",
+			"tags": "Davis_Strait;Atlantic_Basin"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/ocean/region/East_Siberian_Sea/region.geojson
+++ b/ocean/region/East_Siberian_Sea/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "East Siberian Sea",
-			"component": "ocean",
-			"tags": "East_Siberian_Sea;Arctic_Basin",
 			"author": "http://www.marineregions.org/downloads.php#iho",
-			"object": "region"
+			"component": "ocean",
+			"name": "East Siberian Sea",
+			"object": "region",
+			"tags": "East_Siberian_Sea;Arctic_Basin"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/ocean/region/Eastern_China_Sea/region.geojson
+++ b/ocean/region/Eastern_China_Sea/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Eastern China Sea",
-			"component": "ocean",
-			"tags": "Eastern_China_Sea;Pacific_Basin",
 			"author": "http://www.marineregions.org/downloads.php#iho",
-			"object": "region"
+			"component": "ocean",
+			"name": "Eastern China Sea",
+			"object": "region",
+			"tags": "Eastern_China_Sea;Pacific_Basin"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/ocean/region/English_Channel/region.geojson
+++ b/ocean/region/English_Channel/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "English Channel",
-			"component": "ocean",
-			"tags": "English_Channel;Atlantic_Basin",
 			"author": "http://www.marineregions.org/downloads.php#iho",
-			"object": "region"
+			"component": "ocean",
+			"name": "English Channel",
+			"object": "region",
+			"tags": "English_Channel;Atlantic_Basin"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/ocean/region/Flores_Sea/region.geojson
+++ b/ocean/region/Flores_Sea/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Flores Sea",
-			"component": "ocean",
-			"tags": "Flores_Sea;Pacific_Basin",
 			"author": "http://www.marineregions.org/downloads.php#iho",
-			"object": "region"
+			"component": "ocean",
+			"name": "Flores Sea",
+			"object": "region",
+			"tags": "Flores_Sea;Pacific_Basin"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/ocean/region/Global_Ocean_65N_to_65S/region.geojson
+++ b/ocean/region/Global_Ocean_65N_to_65S/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Global Ocean 65N to 65S",
-			"component": "ocean",
-			"tags": "",
 			"author": "Xylar Asay-Davis",
-			"object": "region"
+			"component": "ocean",
+			"name": "Global Ocean 65N to 65S",
+			"object": "region",
+			"tags": ""
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/ocean/region/Great_Australian_Bight_North/region.geojson
+++ b/ocean/region/Great_Australian_Bight_North/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Great Australian Bight North",
-			"component": "ocean",
-			"tags": "Great_Australian_Bight;Indian_Basin",
 			"author": "http://www.marineregions.org/downloads.php#iho",
-			"object": "region"
+			"component": "ocean",
+			"name": "Great Australian Bight North",
+			"object": "region",
+			"tags": "Great_Australian_Bight;Indian_Basin"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/ocean/region/Great_Australian_Bight_South/region.geojson
+++ b/ocean/region/Great_Australian_Bight_South/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Great Australian Bight South",
-			"component": "ocean",
-			"tags": "Great_Australian_Bight;Southern_Ocean_Basin",
 			"author": "http://www.marineregions.org/downloads.php#iho",
-			"object": "region"
+			"component": "ocean",
+			"name": "Great Australian Bight South",
+			"object": "region",
+			"tags": "Great_Australian_Bight;Southern_Ocean_Basin"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/ocean/region/Greenland_Sea/region.geojson
+++ b/ocean/region/Greenland_Sea/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Greenland Sea",
-			"component": "ocean",
-			"tags": "Greenland_Sea;Atlantic_Basin",
 			"author": "http://www.marineregions.org/downloads.php#iho",
-			"object": "region"
+			"component": "ocean",
+			"name": "Greenland Sea",
+			"object": "region",
+			"tags": "Greenland_Sea;Atlantic_Basin"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/ocean/region/Gulf_of_Aden/region.geojson
+++ b/ocean/region/Gulf_of_Aden/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Gulf of Aden",
-			"component": "ocean",
-			"tags": "Gulf_of_Aden;Indian_Basin",
 			"author": "http://www.marineregions.org/downloads.php#iho",
-			"object": "region"
+			"component": "ocean",
+			"name": "Gulf of Aden",
+			"object": "region",
+			"tags": "Gulf_of_Aden;Indian_Basin"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/ocean/region/Gulf_of_Alaska/region.geojson
+++ b/ocean/region/Gulf_of_Alaska/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Gulf of Alaska",
-			"component": "ocean",
-			"tags": "Gulf_of_Alaska;Pacific_Basin",
 			"author": "http://www.marineregions.org/downloads.php#iho",
-			"object": "region"
+			"component": "ocean",
+			"name": "Gulf of Alaska",
+			"object": "region",
+			"tags": "Gulf_of_Alaska;Pacific_Basin"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/ocean/region/Gulf_of_Aqaba/region.geojson
+++ b/ocean/region/Gulf_of_Aqaba/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Gulf of Aqaba",
-			"component": "ocean",
-			"tags": "Gulf_of_Aqaba",
 			"author": "http://www.marineregions.org/downloads.php#iho",
-			"object": "region"
+			"component": "ocean",
+			"name": "Gulf of Aqaba",
+			"object": "region",
+			"tags": "Gulf_of_Aqaba"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/ocean/region/Gulf_of_Boni/region.geojson
+++ b/ocean/region/Gulf_of_Boni/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Gulf of Boni",
-			"component": "ocean",
-			"tags": "Gulf_of_Boni;Pacific_Basin",
 			"author": "http://www.marineregions.org/downloads.php#iho",
-			"object": "region"
+			"component": "ocean",
+			"name": "Gulf of Boni",
+			"object": "region",
+			"tags": "Gulf_of_Boni;Pacific_Basin"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/ocean/region/Gulf_of_Bothnia/region.geojson
+++ b/ocean/region/Gulf_of_Bothnia/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Gulf of Bothnia",
-			"component": "ocean",
-			"tags": "Gulf_of_Bothnia;Atlantic_Basin",
 			"author": "http://www.marineregions.org/downloads.php#iho",
-			"object": "region"
+			"component": "ocean",
+			"name": "Gulf of Bothnia",
+			"object": "region",
+			"tags": "Gulf_of_Bothnia;Atlantic_Basin"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/ocean/region/Gulf_of_California/region.geojson
+++ b/ocean/region/Gulf_of_California/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Gulf of California",
-			"component": "ocean",
-			"tags": "Gulf_of_California;Pacific_Basin",
 			"author": "http://www.marineregions.org/downloads.php#iho",
-			"object": "region"
+			"component": "ocean",
+			"name": "Gulf of California",
+			"object": "region",
+			"tags": "Gulf_of_California;Pacific_Basin"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/ocean/region/Gulf_of_Finland/region.geojson
+++ b/ocean/region/Gulf_of_Finland/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Gulf of Finland",
-			"component": "ocean",
-			"tags": "Gulf_of_Finland;Atlantic_Basin",
 			"author": "http://www.marineregions.org/downloads.php#iho",
-			"object": "region"
+			"component": "ocean",
+			"name": "Gulf of Finland",
+			"object": "region",
+			"tags": "Gulf_of_Finland;Atlantic_Basin"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/ocean/region/Gulf_of_Guinea/region.geojson
+++ b/ocean/region/Gulf_of_Guinea/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Gulf of Guinea",
-			"component": "ocean",
-			"tags": "Gulf_of_Guinea;Atlantic_Basin",
 			"author": "http://www.marineregions.org/downloads.php#iho",
-			"object": "region"
+			"component": "ocean",
+			"name": "Gulf of Guinea",
+			"object": "region",
+			"tags": "Gulf_of_Guinea;Atlantic_Basin"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/ocean/region/Gulf_of_Mexico/region.geojson
+++ b/ocean/region/Gulf_of_Mexico/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Gulf of Mexico",
-			"component": "ocean",
-			"tags": "Gulf_of_Mexico;Atlantic_Basin",
 			"author": "http://www.marineregions.org/downloads.php#iho",
-			"object": "region"
+			"component": "ocean",
+			"name": "Gulf of Mexico",
+			"object": "region",
+			"tags": "Gulf_of_Mexico;Atlantic_Basin"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/ocean/region/Gulf_of_Oman/region.geojson
+++ b/ocean/region/Gulf_of_Oman/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Gulf of Oman",
-			"component": "ocean",
-			"tags": "Gulf_of_Oman;Indian_Basin",
 			"author": "http://www.marineregions.org/downloads.php#iho",
-			"object": "region"
+			"component": "ocean",
+			"name": "Gulf of Oman",
+			"object": "region",
+			"tags": "Gulf_of_Oman;Indian_Basin"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/ocean/region/Gulf_of_Riga/region.geojson
+++ b/ocean/region/Gulf_of_Riga/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Gulf of Riga",
-			"component": "ocean",
-			"tags": "Gulf_of_Riga;Atlantic_Basin",
 			"author": "http://www.marineregions.org/downloads.php#iho",
-			"object": "region"
+			"component": "ocean",
+			"name": "Gulf of Riga",
+			"object": "region",
+			"tags": "Gulf_of_Riga;Atlantic_Basin"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/ocean/region/Gulf_of_St-Lawrence/region.geojson
+++ b/ocean/region/Gulf_of_St-Lawrence/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Gulf of St-Lawrence",
-			"component": "ocean",
-			"tags": "Gulf_of_St-Lawrence;Atlantic_Basin",
 			"author": "http://www.marineregions.org/downloads.php#iho",
-			"object": "region"
+			"component": "ocean",
+			"name": "Gulf of St-Lawrence",
+			"object": "region",
+			"tags": "Gulf_of_St-Lawrence;Atlantic_Basin"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/ocean/region/Gulf_of_Suez/region.geojson
+++ b/ocean/region/Gulf_of_Suez/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Gulf of Suez",
-			"component": "ocean",
-			"tags": "Gulf_of_Suez",
 			"author": "http://www.marineregions.org/downloads.php#iho",
-			"object": "region"
+			"component": "ocean",
+			"name": "Gulf of Suez",
+			"object": "region",
+			"tags": "Gulf_of_Suez"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/ocean/region/Gulf_of_Thailand/region.geojson
+++ b/ocean/region/Gulf_of_Thailand/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Gulf of Thailand",
-			"component": "ocean",
-			"tags": "Gulf_of_Thailand;Pacific_Basin",
 			"author": "http://www.marineregions.org/downloads.php#iho",
-			"object": "region"
+			"component": "ocean",
+			"name": "Gulf of Thailand",
+			"object": "region",
+			"tags": "Gulf_of_Thailand;Pacific_Basin"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/ocean/region/Gulf_of_Tomini/region.geojson
+++ b/ocean/region/Gulf_of_Tomini/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Gulf of Tomini",
-			"component": "ocean",
-			"tags": "Gulf_of_Tomini;Pacific_Basin",
 			"author": "http://www.marineregions.org/downloads.php#iho",
-			"object": "region"
+			"component": "ocean",
+			"name": "Gulf of Tomini",
+			"object": "region",
+			"tags": "Gulf_of_Tomini;Pacific_Basin"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/ocean/region/Halamahera_Sea/region.geojson
+++ b/ocean/region/Halamahera_Sea/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Halamahera Sea",
-			"component": "ocean",
-			"tags": "Halamahera_Sea;Pacific_Basin",
 			"author": "http://www.marineregions.org/downloads.php#iho",
-			"object": "region"
+			"component": "ocean",
+			"name": "Halamahera Sea",
+			"object": "region",
+			"tags": "Halamahera_Sea;Pacific_Basin"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/ocean/region/Hudson_Bay/region.geojson
+++ b/ocean/region/Hudson_Bay/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Hudson Bay",
-			"component": "ocean",
-			"tags": "Hudson_Bay;Atlantic_Basin",
 			"author": "http://www.marineregions.org/downloads.php#iho",
-			"object": "region"
+			"component": "ocean",
+			"name": "Hudson Bay",
+			"object": "region",
+			"tags": "Hudson_Bay;Atlantic_Basin"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/ocean/region/Hudson_Strait/region.geojson
+++ b/ocean/region/Hudson_Strait/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Hudson Strait",
-			"component": "ocean",
-			"tags": "Hudson_Strait;Atlantic_Basin",
 			"author": "http://www.marineregions.org/downloads.php#iho",
-			"object": "region"
+			"component": "ocean",
+			"name": "Hudson Strait",
+			"object": "region",
+			"tags": "Hudson_Strait;Atlantic_Basin"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/ocean/region/Indian_Ocean/region.geojson
+++ b/ocean/region/Indian_Ocean/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Indian Ocean",
-			"component": "ocean",
-			"tags": "Indian_Ocean;Indian_Basin",
 			"author": "http://www.marineregions.org/downloads.php#iho",
-			"object": "region"
+			"component": "ocean",
+			"name": "Indian Ocean",
+			"object": "region",
+			"tags": "Indian_Ocean;Indian_Basin"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/ocean/region/Inland_Sea/region.geojson
+++ b/ocean/region/Inland_Sea/region.geojson
@@ -1,14 +1,13 @@
 {"type": "FeatureCollection",
- "groupName": "enterNameHere",
  "features":
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Inland Sea",
-			"component": "ocean",
-			"tags": "Inland_Sea;Pacific_Basin",
 			"author": "http://www.marineregions.org/downloads.php#iho",
-			"object": "region"
+			"component": "ocean",
+			"name": "Inland Sea",
+			"object": "region",
+			"tags": "Inland_Sea;Pacific_Basin"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/ocean/region/Inner_Seas_off_the_West_Coast_of_Scotland/region.geojson
+++ b/ocean/region/Inner_Seas_off_the_West_Coast_of_Scotland/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Inner Seas off the West Coast of Scotland",
-			"component": "ocean",
-			"tags": "Inner_Seas_off_the_West_Coast_of_Scotland;Atlantic_Basin",
 			"author": "http://www.marineregions.org/downloads.php#iho",
-			"object": "region"
+			"component": "ocean",
+			"name": "Inner Seas off the West Coast of Scotland",
+			"object": "region",
+			"tags": "Inner_Seas_off_the_West_Coast_of_Scotland;Atlantic_Basin"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/ocean/region/Ionian_Sea/region.geojson
+++ b/ocean/region/Ionian_Sea/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Ionian Sea",
-			"component": "ocean",
-			"tags": "Ionian_Sea;Mediterranean_Basin",
 			"author": "http://www.marineregions.org/downloads.php#iho",
-			"object": "region"
+			"component": "ocean",
+			"name": "Ionian Sea",
+			"object": "region",
+			"tags": "Ionian_Sea;Mediterranean_Basin"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/ocean/region/Irish_Sea_and_St_Georges_Channel/region.geojson
+++ b/ocean/region/Irish_Sea_and_St_Georges_Channel/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Irish Sea and St Georges Channel",
-			"component": "ocean",
-			"tags": "Irish_Sea_and_St_Georges_Channel;Atlantic_Basin",
 			"author": "http://www.marineregions.org/downloads.php#iho",
-			"object": "region"
+			"component": "ocean",
+			"name": "Irish Sea and St Georges Channel",
+			"object": "region",
+			"tags": "Irish_Sea_and_St_Georges_Channel;Atlantic_Basin"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/ocean/region/Japan_Sea/region.geojson
+++ b/ocean/region/Japan_Sea/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Japan Sea",
-			"component": "ocean",
-			"tags": "Japan_Sea;Pacific_Basin",
 			"author": "http://www.marineregions.org/downloads.php#iho",
-			"object": "region"
+			"component": "ocean",
+			"name": "Japan Sea",
+			"object": "region",
+			"tags": "Japan_Sea;Pacific_Basin"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/ocean/region/Java_Sea/region.geojson
+++ b/ocean/region/Java_Sea/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Java Sea",
-			"component": "ocean",
-			"tags": "Java_Sea;Pacific_Basin",
 			"author": "http://www.marineregions.org/downloads.php#iho",
-			"object": "region"
+			"component": "ocean",
+			"name": "Java Sea",
+			"object": "region",
+			"tags": "Java_Sea;Pacific_Basin"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/ocean/region/Kara_Sea/region.geojson
+++ b/ocean/region/Kara_Sea/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Kara Sea",
-			"component": "ocean",
-			"tags": "Kara_Sea;Arctic_Basin",
 			"author": "http://www.marineregions.org/downloads.php#iho",
-			"object": "region"
+			"component": "ocean",
+			"name": "Kara Sea",
+			"object": "region",
+			"tags": "Kara_Sea;Arctic_Basin"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/ocean/region/Kattegat/region.geojson
+++ b/ocean/region/Kattegat/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Kattegat",
-			"component": "ocean",
-			"tags": "Kattegat;Atlantic_Basin",
 			"author": "http://www.marineregions.org/downloads.php#iho",
-			"object": "region"
+			"component": "ocean",
+			"name": "Kattegat",
+			"object": "region",
+			"tags": "Kattegat;Atlantic_Basin"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/ocean/region/Labrador_Sea/region.geojson
+++ b/ocean/region/Labrador_Sea/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Labrador Sea",
-			"component": "ocean",
-			"tags": "Labrador_Sea;Atlantic_Basin",
 			"author": "http://www.marineregions.org/downloads.php#iho",
-			"object": "region"
+			"component": "ocean",
+			"name": "Labrador Sea",
+			"object": "region",
+			"tags": "Labrador_Sea;Atlantic_Basin"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/ocean/region/Laccadive_Sea/region.geojson
+++ b/ocean/region/Laccadive_Sea/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Laccadive Sea",
-			"component": "ocean",
-			"tags": "Laccadive_Sea;Indian_Basin",
 			"author": "http://www.marineregions.org/downloads.php#iho",
-			"object": "region"
+			"component": "ocean",
+			"name": "Laccadive Sea",
+			"object": "region",
+			"tags": "Laccadive_Sea;Indian_Basin"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/ocean/region/Laptev_Sea/region.geojson
+++ b/ocean/region/Laptev_Sea/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Laptev Sea",
-			"component": "ocean",
-			"tags": "Laptev_Sea;Arctic_Basin",
 			"author": "http://www.marineregions.org/downloads.php#iho",
-			"object": "region"
+			"component": "ocean",
+			"name": "Laptev Sea",
+			"object": "region",
+			"tags": "Laptev_Sea;Arctic_Basin"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/ocean/region/Ligurian_Sea/region.geojson
+++ b/ocean/region/Ligurian_Sea/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Ligurian Sea",
-			"component": "ocean",
-			"tags": "Ligurian_Sea;Mediterranean_Basin",
 			"author": "http://www.marineregions.org/downloads.php#iho",
-			"object": "region"
+			"component": "ocean",
+			"name": "Ligurian Sea",
+			"object": "region",
+			"tags": "Ligurian_Sea;Mediterranean_Basin"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/ocean/region/Lincoln_Sea/region.geojson
+++ b/ocean/region/Lincoln_Sea/region.geojson
@@ -1,14 +1,13 @@
 {"type": "FeatureCollection",
- "groupName": "enterNameHere",
  "features":
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Lincoln Sea",
-			"component": "ocean",
-			"tags": "Lincoln_Sea;Arctic_Basin",
 			"author": "http://www.marineregions.org/downloads.php#iho",
-			"object": "region"
+			"component": "ocean",
+			"name": "Lincoln Sea",
+			"object": "region",
+			"tags": "Lincoln_Sea;Arctic_Basin"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/ocean/region/MOC_mask_30S/region.geojson
+++ b/ocean/region/MOC_mask_30S/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "MOC mask 30S",
-			"component": "ocean",
-			"tags": "MOC_mask_30S",
 			"author": "Xylar Asay-Davis",
-			"object": "region"
+			"component": "ocean",
+			"name": "MOC mask 30S",
+			"object": "region",
+			"tags": "MOC_mask_30S"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/ocean/region/MOC_mask_6S/region.geojson
+++ b/ocean/region/MOC_mask_6S/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "MOC mask 6S",
-			"component": "ocean",
-			"tags": "MOC_mask_6S",
 			"author": "Xylar Asay-Davis",
-			"object": "region"
+			"component": "ocean",
+			"name": "MOC mask 6S",
+			"object": "region",
+			"tags": "MOC_mask_6S"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/ocean/region/Makassar_Strait/region.geojson
+++ b/ocean/region/Makassar_Strait/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Makassar Strait",
-			"component": "ocean",
-			"tags": "Makassar_Strait;Pacific_Basin",
 			"author": "http://www.marineregions.org/downloads.php#iho",
-			"object": "region"
+			"component": "ocean",
+			"name": "Makassar Strait",
+			"object": "region",
+			"tags": "Makassar_Strait;Pacific_Basin"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/ocean/region/Malacca_Strait/region.geojson
+++ b/ocean/region/Malacca_Strait/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Malacca Strait",
-			"component": "ocean",
-			"tags": "Malacca_Strait;Indian_Basin",
 			"author": "http://www.marineregions.org/downloads.php#iho",
-			"object": "region"
+			"component": "ocean",
+			"name": "Malacca Strait",
+			"object": "region",
+			"tags": "Malacca_Strait;Indian_Basin"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/ocean/region/Mediterranean_Sea_-_Eastern_Basin/region.geojson
+++ b/ocean/region/Mediterranean_Sea_-_Eastern_Basin/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Mediterranean Sea - Eastern Basin",
-			"component": "ocean",
-			"tags": "Mediterranean_Sea_-_Eastern_Basin;Mediterranean_Basin",
 			"author": "http://www.marineregions.org/downloads.php#iho",
-			"object": "region"
+			"component": "ocean",
+			"name": "Mediterranean Sea - Eastern Basin",
+			"object": "region",
+			"tags": "Mediterranean_Sea_-_Eastern_Basin;Mediterranean_Basin"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/ocean/region/Mediterranean_Sea_-_Western_Basin/region.geojson
+++ b/ocean/region/Mediterranean_Sea_-_Western_Basin/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Mediterranean Sea - Western Basin",
-			"component": "ocean",
-			"tags": "Mediterranean_Sea_-_Western_Basin;Mediterranean_Basin",
 			"author": "http://www.marineregions.org/downloads.php#iho",
-			"object": "region"
+			"component": "ocean",
+			"name": "Mediterranean Sea - Western Basin",
+			"object": "region",
+			"tags": "Mediterranean_Sea_-_Western_Basin;Mediterranean_Basin"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/ocean/region/Molukka_Sea/region.geojson
+++ b/ocean/region/Molukka_Sea/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Molukka Sea",
-			"component": "ocean",
-			"tags": "Molukka_Sea;Pacific_Basin",
 			"author": "http://www.marineregions.org/downloads.php#iho",
-			"object": "region"
+			"component": "ocean",
+			"name": "Molukka Sea",
+			"object": "region",
+			"tags": "Molukka_Sea;Pacific_Basin"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/ocean/region/Mozambique_Channel/region.geojson
+++ b/ocean/region/Mozambique_Channel/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Mozambique Channel",
-			"component": "ocean",
-			"tags": "Mozambique_Channel;Indian_Basin",
 			"author": "http://www.marineregions.org/downloads.php#iho",
-			"object": "region"
+			"component": "ocean",
+			"name": "Mozambique Channel",
+			"object": "region",
+			"tags": "Mozambique_Channel;Indian_Basin"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/ocean/region/North_Atlantic_Ocean/region.geojson
+++ b/ocean/region/North_Atlantic_Ocean/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "North Atlantic Ocean",
-			"component": "ocean",
-			"tags": "North_Atlantic_Ocean;Atlantic_Basin",
 			"author": "http://www.marineregions.org/downloads.php#iho",
-			"object": "region"
+			"component": "ocean",
+			"name": "North Atlantic Ocean",
+			"object": "region",
+			"tags": "North_Atlantic_Ocean;Atlantic_Basin"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/ocean/region/North_Pacific_Ocean/region.geojson
+++ b/ocean/region/North_Pacific_Ocean/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "North Pacific Ocean",
-			"component": "ocean",
-			"tags": "North_Pacific_Ocean;Pacific_Basin",
 			"author": "http://www.marineregions.org/downloads.php#iho",
-			"object": "region"
+			"component": "ocean",
+			"name": "North Pacific Ocean",
+			"object": "region",
+			"tags": "North_Pacific_Ocean;Pacific_Basin"
 		 },
 		 "geometry":
 			{"type": "MultiPolygon",

--- a/ocean/region/North_Sea/region.geojson
+++ b/ocean/region/North_Sea/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "North Sea",
-			"component": "ocean",
-			"tags": "North_Sea;Atlantic_Basin",
 			"author": "http://www.marineregions.org/downloads.php#iho",
-			"object": "region"
+			"component": "ocean",
+			"name": "North Sea",
+			"object": "region",
+			"tags": "North_Sea;Atlantic_Basin"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/ocean/region/Northwestern_Passages/region.geojson
+++ b/ocean/region/Northwestern_Passages/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Northwestern Passages",
-			"component": "ocean",
-			"tags": "Northwestern_Passages;Arctic_Basin",
 			"author": "http://www.marineregions.org/downloads.php#iho",
-			"object": "region"
+			"component": "ocean",
+			"name": "Northwestern Passages",
+			"object": "region",
+			"tags": "Northwestern_Passages;Arctic_Basin"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/ocean/region/Norwegian_Sea/region.geojson
+++ b/ocean/region/Norwegian_Sea/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Norwegian Sea",
-			"component": "ocean",
-			"tags": "Norwegian_Sea;Atlantic_Basin",
 			"author": "http://www.marineregions.org/downloads.php#iho",
-			"object": "region"
+			"component": "ocean",
+			"name": "Norwegian Sea",
+			"object": "region",
+			"tags": "Norwegian_Sea;Atlantic_Basin"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/ocean/region/Persian_Gulf/region.geojson
+++ b/ocean/region/Persian_Gulf/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Persian Gulf",
-			"component": "ocean",
-			"tags": "Persian_Gulf",
 			"author": "http://www.marineregions.org/downloads.php#iho",
-			"object": "region"
+			"component": "ocean",
+			"name": "Persian Gulf",
+			"object": "region",
+			"tags": "Persian_Gulf"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/ocean/region/Philippine_Sea/region.geojson
+++ b/ocean/region/Philippine_Sea/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Philippine Sea",
-			"component": "ocean",
-			"tags": "Philippine_Sea;Pacific_Basin",
 			"author": "http://www.marineregions.org/downloads.php#iho",
-			"object": "region"
+			"component": "ocean",
+			"name": "Philippine Sea",
+			"object": "region",
+			"tags": "Philippine_Sea;Pacific_Basin"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/ocean/region/Red_Sea/region.geojson
+++ b/ocean/region/Red_Sea/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Red Sea",
-			"component": "ocean",
-			"tags": "Red_Sea",
 			"author": "http://www.marineregions.org/downloads.php#iho",
-			"object": "region"
+			"component": "ocean",
+			"name": "Red Sea",
+			"object": "region",
+			"tags": "Red_Sea"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/ocean/region/Rio_de_La_Plata/region.geojson
+++ b/ocean/region/Rio_de_La_Plata/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Rio de La Plata",
-			"component": "ocean",
-			"tags": "Rio_de_La_Plata;Atlantic_Basin",
 			"author": "http://www.marineregions.org/downloads.php#iho",
-			"object": "region"
+			"component": "ocean",
+			"name": "Rio de La Plata",
+			"object": "region",
+			"tags": "Rio_de_La_Plata;Atlantic_Basin"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/ocean/region/Savu_Sea/region.geojson
+++ b/ocean/region/Savu_Sea/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Savu Sea",
-			"component": "ocean",
-			"tags": "Savu_Sea;Pacific_Basin",
 			"author": "http://www.marineregions.org/downloads.php#iho",
-			"object": "region"
+			"component": "ocean",
+			"name": "Savu Sea",
+			"object": "region",
+			"tags": "Savu_Sea;Pacific_Basin"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/ocean/region/Sea_of_Azov/region.geojson
+++ b/ocean/region/Sea_of_Azov/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Sea of Azov",
-			"component": "ocean",
-			"tags": "Sea_of_Azov",
 			"author": "http://www.marineregions.org/downloads.php#iho",
-			"object": "region"
+			"component": "ocean",
+			"name": "Sea of Azov",
+			"object": "region",
+			"tags": "Sea_of_Azov"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/ocean/region/Sea_of_Marmara/region.geojson
+++ b/ocean/region/Sea_of_Marmara/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Sea of Marmara",
-			"component": "ocean",
-			"tags": "Sea_of_Marmara",
 			"author": "http://www.marineregions.org/downloads.php#iho",
-			"object": "region"
+			"component": "ocean",
+			"name": "Sea of Marmara",
+			"object": "region",
+			"tags": "Sea_of_Marmara"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/ocean/region/Sea_of_Okhotsk/region.geojson
+++ b/ocean/region/Sea_of_Okhotsk/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Sea of Okhotsk",
-			"component": "ocean",
-			"tags": "Sea_of_Okhotsk;Pacific_Basin",
 			"author": "http://www.marineregions.org/downloads.php#iho",
-			"object": "region"
+			"component": "ocean",
+			"name": "Sea of Okhotsk",
+			"object": "region",
+			"tags": "Sea_of_Okhotsk;Pacific_Basin"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/ocean/region/Singapore_Strait/region.geojson
+++ b/ocean/region/Singapore_Strait/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Singapore Strait",
-			"component": "ocean",
-			"tags": "Singapore_Strait;Pacific_Basin",
 			"author": "http://www.marineregions.org/downloads.php#iho",
-			"object": "region"
+			"component": "ocean",
+			"name": "Singapore Strait",
+			"object": "region",
+			"tags": "Singapore_Strait;Pacific_Basin"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/ocean/region/Skaggerak/region.geojson
+++ b/ocean/region/Skaggerak/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Skaggerak",
-			"component": "ocean",
-			"tags": "Skaggerak;Atlantic_Basin",
 			"author": "http://www.marineregions.org/downloads.php#iho",
-			"object": "region"
+			"component": "ocean",
+			"name": "Skaggerak",
+			"object": "region",
+			"tags": "Skaggerak;Atlantic_Basin"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/ocean/region/Solomon_Sea/region.geojson
+++ b/ocean/region/Solomon_Sea/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Solomon Sea",
-			"component": "ocean",
-			"tags": "Solomon_Sea;Pacific_Basin",
 			"author": "http://www.marineregions.org/downloads.php#iho",
-			"object": "region"
+			"component": "ocean",
+			"name": "Solomon Sea",
+			"object": "region",
+			"tags": "Solomon_Sea;Pacific_Basin"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/ocean/region/South_Atlantic_Ocean/region.geojson
+++ b/ocean/region/South_Atlantic_Ocean/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "South Atlantic Ocean",
-			"component": "ocean",
-			"tags": "South_Atlantic_Ocean;Atlantic_Basin",
 			"author": "http://www.marineregions.org/downloads.php#iho",
-			"object": "region"
+			"component": "ocean",
+			"name": "South Atlantic Ocean",
+			"object": "region",
+			"tags": "South_Atlantic_Ocean;Atlantic_Basin"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/ocean/region/South_China_Sea/region.geojson
+++ b/ocean/region/South_China_Sea/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "South China Sea",
-			"component": "ocean",
-			"tags": "South_China_Sea;Pacific_Basin",
 			"author": "http://www.marineregions.org/downloads.php#iho",
-			"object": "region"
+			"component": "ocean",
+			"name": "South China Sea",
+			"object": "region",
+			"tags": "South_China_Sea;Pacific_Basin"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/ocean/region/South_Pacific_Ocean/region.geojson
+++ b/ocean/region/South_Pacific_Ocean/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "South Pacific Ocean",
-			"component": "ocean",
-			"tags": "South_Pacific_Ocean;Pacific_Basin",
 			"author": "http://www.marineregions.org/downloads.php#iho",
-			"object": "region"
+			"component": "ocean",
+			"name": "South Pacific Ocean",
+			"object": "region",
+			"tags": "South_Pacific_Ocean;Pacific_Basin"
 		 },
 		 "geometry":
 			{"type": "MultiPolygon",

--- a/ocean/region/Southern_Ocean/region.geojson
+++ b/ocean/region/Southern_Ocean/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Southern Ocean",
-			"component": "ocean",
-			"tags": "Southern_Ocean;Southern_Ocean_Basin",
 			"author": "Xylar Asay-Davis",
-			"object": "region"
+			"component": "ocean",
+			"name": "Southern Ocean",
+			"object": "region",
+			"tags": "Southern_Ocean;Southern_Ocean_Basin"
 		 },
 		 "geometry":
 			{"type": "MultiPolygon",

--- a/ocean/region/Strait_of_Gibraltar/region.geojson
+++ b/ocean/region/Strait_of_Gibraltar/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Strait of Gibraltar",
-			"component": "ocean",
-			"tags": "Strait_of_Gibraltar;Mediterranean_Basin",
 			"author": "http://www.marineregions.org/downloads.php#iho",
-			"object": "region"
+			"component": "ocean",
+			"name": "Strait of Gibraltar",
+			"object": "region",
+			"tags": "Strait_of_Gibraltar;Mediterranean_Basin"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/ocean/region/Sulu_Sea/region.geojson
+++ b/ocean/region/Sulu_Sea/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Sulu Sea",
-			"component": "ocean",
-			"tags": "Sulu_Sea;Pacific_Basin",
 			"author": "http://www.marineregions.org/downloads.php#iho",
-			"object": "region"
+			"component": "ocean",
+			"name": "Sulu Sea",
+			"object": "region",
+			"tags": "Sulu_Sea;Pacific_Basin"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/ocean/region/Tasman_Sea_North/region.geojson
+++ b/ocean/region/Tasman_Sea_North/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Tasman Sea North",
-			"component": "ocean",
-			"tags": "Tasman_Sea;Pacific_Basin",
 			"author": "http://www.marineregions.org/downloads.php#iho",
-			"object": "region"
+			"component": "ocean",
+			"name": "Tasman Sea North",
+			"object": "region",
+			"tags": "Tasman_Sea;Pacific_Basin"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/ocean/region/Tasman_Sea_South/region.geojson
+++ b/ocean/region/Tasman_Sea_South/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Tasman Sea South",
-			"component": "ocean",
-			"tags": "Tasman_Sea;Southern_Ocean_Basin",
 			"author": "http://www.marineregions.org/downloads.php#iho",
-			"object": "region"
+			"component": "ocean",
+			"name": "Tasman Sea South",
+			"object": "region",
+			"tags": "Tasman_Sea;Southern_Ocean_Basin"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/ocean/region/The_Coastal_Waters_of_Southeast_Alaska_and_British_Columbia/region.geojson
+++ b/ocean/region/The_Coastal_Waters_of_Southeast_Alaska_and_British_Columbia/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "The Coastal Waters of Southeast Alaska and British Columbia",
-			"component": "ocean",
-			"tags": "The_Coastal_Waters_of_Southeast_Alaska_and_British_Columbia;Pacific_Basin",
 			"author": "http://www.marineregions.org/downloads.php#iho",
-			"object": "region"
+			"component": "ocean",
+			"name": "The Coastal Waters of Southeast Alaska and British Columbia",
+			"object": "region",
+			"tags": "The_Coastal_Waters_of_Southeast_Alaska_and_British_Columbia;Pacific_Basin"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/ocean/region/Timor_Sea/region.geojson
+++ b/ocean/region/Timor_Sea/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Timor Sea",
-			"component": "ocean",
-			"tags": "Timor_Sea;Pacific_Basin",
 			"author": "http://www.marineregions.org/downloads.php#iho",
-			"object": "region"
+			"component": "ocean",
+			"name": "Timor Sea",
+			"object": "region",
+			"tags": "Timor_Sea;Pacific_Basin"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/ocean/region/Tyrrhenian_Sea/region.geojson
+++ b/ocean/region/Tyrrhenian_Sea/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Tyrrhenian Sea",
-			"component": "ocean",
-			"tags": "Tyrrhenian_Sea;Mediterranean_Basin",
 			"author": "http://www.marineregions.org/downloads.php#iho",
-			"object": "region"
+			"component": "ocean",
+			"name": "Tyrrhenian Sea",
+			"object": "region",
+			"tags": "Tyrrhenian_Sea;Mediterranean_Basin"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/ocean/region/White_Sea/region.geojson
+++ b/ocean/region/White_Sea/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "White Sea",
-			"component": "ocean",
-			"tags": "White_Sea;Arctic_Basin",
 			"author": "http://www.marineregions.org/downloads.php#iho",
-			"object": "region"
+			"component": "ocean",
+			"name": "White Sea",
+			"object": "region",
+			"tags": "White_Sea;Arctic_Basin"
 		 },
 		 "geometry":
 			{"type": "Polygon",

--- a/ocean/region/Yellow_Sea/region.geojson
+++ b/ocean/region/Yellow_Sea/region.geojson
@@ -3,11 +3,11 @@
 	[
 		{"type": "Feature",
 		 "properties": {
-			"name": "Yellow Sea",
-			"component": "ocean",
-			"tags": "Yellow_Sea;Pacific_Basin",
 			"author": "http://www.marineregions.org/downloads.php#iho",
-			"object": "region"
+			"component": "ocean",
+			"name": "Yellow Sea",
+			"object": "region",
+			"tags": "Yellow_Sea;Pacific_Basin"
 		 },
 		 "geometry":
 			{"type": "Polygon",


### PR DESCRIPTION
This merge simply merges, then re-splits all features
in the database so that property keys are now alphabetized.
This way, future commits involving merge/split operations
are not complicated by this alphabetization.