### PR TITLE
Adding ocean point locations

### DIFF
--- a/ocean/point/Equatorial_Pacific_E145.0_N00.0/point.geojson
+++ b/ocean/point/Equatorial_Pacific_E145.0_N00.0/point.geojson
@@ -1,0 +1,19 @@
+{"type": "FeatureCollection",
+ "features":
+	[
+		{"type": "Feature",
+		 "properties": {
+			"name": "Equatorial_Pacific_E145.0_N00.0",
+			"component": "ocean",
+			"tags": "",
+			"author": "Todd Ringler",
+			"object": "point"
+		 },
+		 "geometry":
+			{"type": "Point",
+			 "coordinates":
+			[ 145.000000, 0.000000]
+			}
+		}
+	]
+}

--- a/ocean/point/Equatorial_Pacific_E155.0_N00.0/point.geojson
+++ b/ocean/point/Equatorial_Pacific_E155.0_N00.0/point.geojson
@@ -1,0 +1,19 @@
+{"type": "FeatureCollection",
+ "features":
+	[
+		{"type": "Feature",
+		 "properties": {
+			"name": "Equatorial_Pacific_E155.0_N00.0",
+			"component": "ocean",
+			"tags": "",
+			"author": "Todd Ringler",
+			"object": "point"
+		 },
+		 "geometry":
+			{"type": "Point",
+			 "coordinates":
+			[ 155.000000, 0.000000]
+			}
+		}
+	]
+}

--- a/ocean/point/Equatorial_Pacific_E165.0_N00.0/point.geojson
+++ b/ocean/point/Equatorial_Pacific_E165.0_N00.0/point.geojson
@@ -1,0 +1,19 @@
+{"type": "FeatureCollection",
+ "features":
+	[
+		{"type": "Feature",
+		 "properties": {
+			"name": "Equatorial_Pacific_E165.0_N00.0",
+			"component": "ocean",
+			"tags": "",
+			"author": "Todd Ringler",
+			"object": "point"
+		 },
+		 "geometry":
+			{"type": "Point",
+			 "coordinates":
+			[ 165.000000, 0.000000]
+			}
+		}
+	]
+}

--- a/ocean/point/Equatorial_Pacific_E175.0_N00.0/point.geojson
+++ b/ocean/point/Equatorial_Pacific_E175.0_N00.0/point.geojson
@@ -1,0 +1,19 @@
+{"type": "FeatureCollection",
+ "features":
+	[
+		{"type": "Feature",
+		 "properties": {
+			"name": "Equatorial_Pacific_E175.0_N00.0",
+			"component": "ocean",
+			"tags": "",
+			"author": "Todd Ringler",
+			"object": "point"
+		 },
+		 "geometry":
+			{"type": "Point",
+			 "coordinates":
+			[ 175.000000, 0.000000]
+			}
+		}
+	]
+}

--- a/ocean/point/Equatorial_Pacific_W090.0_N00.0/point.geojson
+++ b/ocean/point/Equatorial_Pacific_W090.0_N00.0/point.geojson
@@ -1,0 +1,19 @@
+{"type": "FeatureCollection",
+ "features":
+	[
+		{"type": "Feature",
+		 "properties": {
+			"name": "Equatorial_Pacific_W090.0_N00.0",
+			"component": "ocean",
+			"tags": "",
+			"author": "Todd Ringler",
+			"object": "point"
+		 },
+		 "geometry":
+			{"type": "Point",
+			 "coordinates":
+			[ -90.000000, 0.000000]
+			}
+		}
+	]
+}

--- a/ocean/point/Equatorial_Pacific_W095.0_N00.0/point.geojson
+++ b/ocean/point/Equatorial_Pacific_W095.0_N00.0/point.geojson
@@ -1,0 +1,19 @@
+{"type": "FeatureCollection",
+ "features":
+	[
+		{"type": "Feature",
+		 "properties": {
+			"name": "Equatorial_Pacific_W095.0_N00.0",
+			"component": "ocean",
+			"tags": "",
+			"author": "Todd Ringler",
+			"object": "point"
+		 },
+		 "geometry":
+			{"type": "Point",
+			 "coordinates":
+			[ -95.000000, 0.000000]
+			}
+		}
+	]
+}

--- a/ocean/point/Equatorial_Pacific_W105.0_N00.0/point.geojson
+++ b/ocean/point/Equatorial_Pacific_W105.0_N00.0/point.geojson
@@ -1,0 +1,19 @@
+{"type": "FeatureCollection",
+ "features":
+	[
+		{"type": "Feature",
+		 "properties": {
+			"name": "Equatorial_Pacific_W105.0_N00.0",
+			"component": "ocean",
+			"tags": "",
+			"author": "Todd Ringler",
+			"object": "point"
+		 },
+		 "geometry":
+			{"type": "Point",
+			 "coordinates":
+			[ -105.000000, 0.000000]
+			}
+		}
+	]
+}

--- a/ocean/point/Equatorial_Pacific_W115.0_N00.0/point.geojson
+++ b/ocean/point/Equatorial_Pacific_W115.0_N00.0/point.geojson
@@ -1,0 +1,19 @@
+{"type": "FeatureCollection",
+ "features":
+	[
+		{"type": "Feature",
+		 "properties": {
+			"name": "Equatorial_Pacific_W115.0_N00.0",
+			"component": "ocean",
+			"tags": "",
+			"author": "Todd Ringler",
+			"object": "point"
+		 },
+		 "geometry":
+			{"type": "Point",
+			 "coordinates":
+			[ -115.000000, 0.000000]
+			}
+		}
+	]
+}

--- a/ocean/point/Equatorial_Pacific_W125.0_N00.0/point.geojson
+++ b/ocean/point/Equatorial_Pacific_W125.0_N00.0/point.geojson
@@ -1,0 +1,19 @@
+{"type": "FeatureCollection",
+ "features":
+	[
+		{"type": "Feature",
+		 "properties": {
+			"name": "Equatorial_Pacific_W125.0_N00.0",
+			"component": "ocean",
+			"tags": "",
+			"author": "Todd Ringler",
+			"object": "point"
+		 },
+		 "geometry":
+			{"type": "Point",
+			 "coordinates":
+			[ -125.000000, 0.000000]
+			}
+		}
+	]
+}

--- a/ocean/point/Equatorial_Pacific_W135.0_N00.0/point.geojson
+++ b/ocean/point/Equatorial_Pacific_W135.0_N00.0/point.geojson
@@ -1,0 +1,19 @@
+{"type": "FeatureCollection",
+ "features":
+	[
+		{"type": "Feature",
+		 "properties": {
+			"name": "Equatorial_Pacific_W135.0_N00.0",
+			"component": "ocean",
+			"tags": "",
+			"author": "Todd Ringler",
+			"object": "point"
+		 },
+		 "geometry":
+			{"type": "Point",
+			 "coordinates":
+			[ -135.000000, 0.000000]
+			}
+		}
+	]
+}

--- a/ocean/point/Equatorial_Pacific_W145.0_N00.0/point.geojson
+++ b/ocean/point/Equatorial_Pacific_W145.0_N00.0/point.geojson
@@ -1,0 +1,19 @@
+{"type": "FeatureCollection",
+ "features":
+	[
+		{"type": "Feature",
+		 "properties": {
+			"name": "Equatorial_Pacific_W145.0_N00.0",
+			"component": "ocean",
+			"tags": "",
+			"author": "Todd Ringler",
+			"object": "point"
+		 },
+		 "geometry":
+			{"type": "Point",
+			 "coordinates":
+			[ -145.000000, 0.000000]
+			}
+		}
+	]
+}

--- a/ocean/point/Equatorial_Pacific_W155.0_N00.0/point.geojson
+++ b/ocean/point/Equatorial_Pacific_W155.0_N00.0/point.geojson
@@ -1,0 +1,19 @@
+{"type": "FeatureCollection",
+ "features":
+	[
+		{"type": "Feature",
+		 "properties": {
+			"name": "Equatorial_Pacific_W155.0_N00.0",
+			"component": "ocean",
+			"tags": "",
+			"author": "Todd Ringler",
+			"object": "point"
+		 },
+		 "geometry":
+			{"type": "Point",
+			 "coordinates":
+			[ -155.000000, 0.000000]
+			}
+		}
+	]
+}

--- a/ocean/point/Equatorial_Pacific_W155.0_N02.0/point.geojson
+++ b/ocean/point/Equatorial_Pacific_W155.0_N02.0/point.geojson
@@ -1,0 +1,19 @@
+{"type": "FeatureCollection",
+ "features":
+	[
+		{"type": "Feature",
+		 "properties": {
+			"name": "Equatorial_Pacific_W155.0_N02.0",
+			"component": "ocean",
+			"tags": "",
+			"author": "Todd Ringler",
+			"object": "point"
+		 },
+		 "geometry":
+			{"type": "Point",
+			 "coordinates":
+			[ -155.000000, 2.000000]
+			}
+		}
+	]
+}

--- a/ocean/point/Equatorial_Pacific_W155.0_N04.0/point.geojson
+++ b/ocean/point/Equatorial_Pacific_W155.0_N04.0/point.geojson
@@ -1,0 +1,19 @@
+{"type": "FeatureCollection",
+ "features":
+	[
+		{"type": "Feature",
+		 "properties": {
+			"name": "Equatorial_Pacific_W155.0_N04.0",
+			"component": "ocean",
+			"tags": "",
+			"author": "Todd Ringler",
+			"object": "point"
+		 },
+		 "geometry":
+			{"type": "Point",
+			 "coordinates":
+			[ -155.000000, 4.000000]
+			}
+		}
+	]
+}

--- a/ocean/point/Equatorial_Pacific_W155.0_N06.0/point.geojson
+++ b/ocean/point/Equatorial_Pacific_W155.0_N06.0/point.geojson
@@ -1,0 +1,19 @@
+{"type": "FeatureCollection",
+ "features":
+	[
+		{"type": "Feature",
+		 "properties": {
+			"name": "Equatorial_Pacific_W155.0_N06.0",
+			"component": "ocean",
+			"tags": "",
+			"author": "Todd Ringler",
+			"object": "point"
+		 },
+		 "geometry":
+			{"type": "Point",
+			 "coordinates":
+			[ -155.000000, 6.000000]
+			}
+		}
+	]
+}

--- a/ocean/point/Equatorial_Pacific_W155.0_N08.0/point.geojson
+++ b/ocean/point/Equatorial_Pacific_W155.0_N08.0/point.geojson
@@ -1,0 +1,19 @@
+{"type": "FeatureCollection",
+ "features":
+	[
+		{"type": "Feature",
+		 "properties": {
+			"name": "Equatorial_Pacific_W155.0_N08.0",
+			"component": "ocean",
+			"tags": "",
+			"author": "Todd Ringler",
+			"object": "point"
+		 },
+		 "geometry":
+			{"type": "Point",
+			 "coordinates":
+			[ -155.000000, 8.000000]
+			}
+		}
+	]
+}

--- a/ocean/point/Equatorial_Pacific_W155.0_N10.0/point.geojson
+++ b/ocean/point/Equatorial_Pacific_W155.0_N10.0/point.geojson
@@ -1,0 +1,19 @@
+{"type": "FeatureCollection",
+ "features":
+	[
+		{"type": "Feature",
+		 "properties": {
+			"name": "Equatorial_Pacific_W155.0_N10.0",
+			"component": "ocean",
+			"tags": "",
+			"author": "Todd Ringler",
+			"object": "point"
+		 },
+		 "geometry":
+			{"type": "Point",
+			 "coordinates":
+			[ -155.000000, 10.000000]
+			}
+		}
+	]
+}

--- a/ocean/point/Equatorial_Pacific_W155.0_S02.0/point.geojson
+++ b/ocean/point/Equatorial_Pacific_W155.0_S02.0/point.geojson
@@ -1,0 +1,19 @@
+{"type": "FeatureCollection",
+ "features":
+	[
+		{"type": "Feature",
+		 "properties": {
+			"name": "Equatorial_Pacific_W155.0_S02.0",
+			"component": "ocean",
+			"tags": "",
+			"author": "Todd Ringler",
+			"object": "point"
+		 },
+		 "geometry":
+			{"type": "Point",
+			 "coordinates":
+			[ -155.000000, -2.000000]
+			}
+		}
+	]
+}

--- a/ocean/point/Equatorial_Pacific_W155.0_S04.0/point.geojson
+++ b/ocean/point/Equatorial_Pacific_W155.0_S04.0/point.geojson
@@ -1,0 +1,19 @@
+{"type": "FeatureCollection",
+ "features":
+	[
+		{"type": "Feature",
+		 "properties": {
+			"name": "Equatorial_Pacific_W155.0_S04.0",
+			"component": "ocean",
+			"tags": "",
+			"author": "Todd Ringler",
+			"object": "point"
+		 },
+		 "geometry":
+			{"type": "Point",
+			 "coordinates":
+			[ -155.000000, -4.000000]
+			}
+		}
+	]
+}

--- a/ocean/point/Equatorial_Pacific_W155.0_S06.0/point.geojson
+++ b/ocean/point/Equatorial_Pacific_W155.0_S06.0/point.geojson
@@ -1,0 +1,19 @@
+{"type": "FeatureCollection",
+ "features":
+	[
+		{"type": "Feature",
+		 "properties": {
+			"name": "Equatorial_Pacific_W155.0_S06.0",
+			"component": "ocean",
+			"tags": "",
+			"author": "Todd Ringler",
+			"object": "point"
+		 },
+		 "geometry":
+			{"type": "Point",
+			 "coordinates":
+			[ -155.000000, -6.000000]
+			}
+		}
+	]
+}

--- a/ocean/point/Equatorial_Pacific_W155.0_S08.0/point.geojson
+++ b/ocean/point/Equatorial_Pacific_W155.0_S08.0/point.geojson
@@ -1,0 +1,19 @@
+{"type": "FeatureCollection",
+ "features":
+	[
+		{"type": "Feature",
+		 "properties": {
+			"name": "Equatorial_Pacific_W155.0_S08.0",
+			"component": "ocean",
+			"tags": "",
+			"author": "Todd Ringler",
+			"object": "point"
+		 },
+		 "geometry":
+			{"type": "Point",
+			 "coordinates":
+			[ -155.000000, -8.000000]
+			}
+		}
+	]
+}

--- a/ocean/point/Equatorial_Pacific_W155.0_S10.0/point.geojson
+++ b/ocean/point/Equatorial_Pacific_W155.0_S10.0/point.geojson
@@ -1,0 +1,19 @@
+{"type": "FeatureCollection",
+ "features":
+	[
+		{"type": "Feature",
+		 "properties": {
+			"name": "Equatorial_Pacific_W155.0_S10.0",
+			"component": "ocean",
+			"tags": "",
+			"author": "Todd Ringler",
+			"object": "point"
+		 },
+		 "geometry":
+			{"type": "Point",
+			 "coordinates":
+			[ -155.000000, -10.000000]
+			}
+		}
+	]
+}

--- a/ocean/point/Equatorial_Pacific_W165.0_N00.0/point.geojson
+++ b/ocean/point/Equatorial_Pacific_W165.0_N00.0/point.geojson
@@ -1,0 +1,19 @@
+{"type": "FeatureCollection",
+ "features":
+	[
+		{"type": "Feature",
+		 "properties": {
+			"name": "Equatorial_Pacific_W165.0_N00.0",
+			"component": "ocean",
+			"tags": "",
+			"author": "Todd Ringler",
+			"object": "point"
+		 },
+		 "geometry":
+			{"type": "Point",
+			 "coordinates":
+			[ -165.000000, 0.000000]
+			}
+		}
+	]
+}

--- a/ocean/point/Equatorial_Pacific_W175.0_N00.0/point.geojson
+++ b/ocean/point/Equatorial_Pacific_W175.0_N00.0/point.geojson
@@ -1,0 +1,19 @@
+{"type": "FeatureCollection",
+ "features":
+	[
+		{"type": "Feature",
+		 "properties": {
+			"name": "Equatorial_Pacific_W175.0_N00.0",
+			"component": "ocean",
+			"tags": "",
+			"author": "Todd Ringler",
+			"object": "point"
+		 },
+		 "geometry":
+			{"type": "Point",
+			 "coordinates":
+			[ -175.000000, 0.000000]
+			}
+		}
+	]
+}

--- a/ocean/point/Southern_Ocean_Drake_Passage_W070.0_S55.0/point.geojson
+++ b/ocean/point/Southern_Ocean_Drake_Passage_W070.0_S55.0/point.geojson
@@ -1,0 +1,19 @@
+{"type": "FeatureCollection",
+ "features":
+	[
+		{"type": "Feature",
+		 "properties": {
+			"name": "Southern_Ocean_Drake_Passage_W070.0_S55.0",
+			"component": "ocean",
+			"tags": "",
+			"author": "Todd Ringler",
+			"object": "point"
+		 },
+		 "geometry":
+			{"type": "Point",
+			 "coordinates":
+			[ -70.000000, -55.000000]
+			}
+		}
+	]
+}

--- a/ocean/point/Southern_Ocean_Drake_Passage_W070.0_S60.0/point.geojson
+++ b/ocean/point/Southern_Ocean_Drake_Passage_W070.0_S60.0/point.geojson
@@ -1,0 +1,19 @@
+{"type": "FeatureCollection",
+ "features":
+	[
+		{"type": "Feature",
+		 "properties": {
+			"name": "Southern_Ocean_Drake_Passage_W070.0_S60.0",
+			"component": "ocean",
+			"tags": "",
+			"author": "Todd Ringler",
+			"object": "point"
+		 },
+		 "geometry":
+			{"type": "Point",
+			 "coordinates":
+			[ -70.000000, -60.000000]
+			}
+		}
+	]
+}

--- a/ocean/point/Southern_Ocean_Drake_Passage_W070.0_S65.0/point.geojson
+++ b/ocean/point/Southern_Ocean_Drake_Passage_W070.0_S65.0/point.geojson
@@ -1,0 +1,19 @@
+{"type": "FeatureCollection",
+ "features":
+	[
+		{"type": "Feature",
+		 "properties": {
+			"name": "Southern_Ocean_Drake_Passage_W070.0_S65.0",
+			"component": "ocean",
+			"tags": "",
+			"author": "Todd Ringler",
+			"object": "point"
+		 },
+		 "geometry":
+			{"type": "Point",
+			 "coordinates":
+			[ -70.000000, -65.000000]
+			}
+		}
+	]
+}


### PR DESCRIPTION
This merge adds some standard ocean point locations which can be used
as either seed locations or to help get diagnostic information out of a
model.