### PR TITLE
Adds link to provenance for ocean regions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,12 @@
-This repository will house definitions of geometric features. These features
+This repository houses definitions of geometric features. These features
 can include regions, transects, and points. Currently they are described in
-geojson format.
+geojson format.  For example, here are some regions for Antarctica.
+
+![alt text](https://cloud.githubusercontent.com/assets/4179064/12921663/93282b64-cf4e-11e5-9260-a78dfadc4459.png "Antarctica regions")
+
+Data for regions has been derived from sources listed in the
+[contributors file](contributors/CONTRIBUTORS.md) as specified
+via the `author` field in each `geojson` file.
 
 The scripts in the top level directory can be used to help maintain and use
 this repository. All of them can be run with the -h flag to get usage

--- a/contributors/CONTRIBUTORS.md
+++ b/contributors/CONTRIBUTORS.md
@@ -1,0 +1,13 @@
+# Data sources
+
+Data sources and authors of the regions may be updated from the repository via
+this [script](list_contributors.sh):
+
+List populated on 2016-04-05 13:10:
+
+ * Todd Ringler
+ * Xylar Asay-Davis
+ * http://icesat4.gsfc.nasa.gov/cryo_data/ant_grn_drainage_systems.php
+ * http://www.marineregions.org/downloads.php#iho
+ * http://www.naturalearthdata.com/
+ * https://www.bas.ac.uk/project/bedmap-2/

--- a/contributors/CONTRIBUTORS_HEADER
+++ b/contributors/CONTRIBUTORS_HEADER
@@ -1,0 +1,5 @@
+# Data sources
+
+Data sources and authors of the regions may be updated from the repository via
+this [script](list_contributors.sh):
+

--- a/contributors/list_contributors.py
+++ b/contributors/list_contributors.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python
+"""
+Determines contributors for geojson files and makes CONTRIBUTORS.md file
+
+Phillip J. Wolfram
+04/05/2016
+"""
+
+import os
+import subprocess
+import shutil
+import datetime
+import re
+
+
+def append_to_file(aline, afile):
+    """ appends aline to afile """
+    with open(afile, "a") as fid:
+        fid.write(aline)
+        if aline[-1] != '\n':
+            fid.write('\n')
+
+def build_contrib_file():
+    """ builds the contributor file CONTRIBUTORS.md """
+    # get file directories
+    gitroot = subprocess.check_output(['git', 'rev-parse', '--show-toplevel']).replace('\n', '')
+    contribdir = gitroot + '/contributors'
+    contribfile = contribdir + '/CONTRIBUTORS.md'
+
+    # go to git root
+    os.chdir(gitroot)
+
+    # build up contrib file
+    shutil.copyfile(contribdir + '/CONTRIBUTORS_HEADER', contribfile)
+
+    append_to_file('List populated on %s:'%
+                   (datetime.datetime.now().strftime("%Y-%m-%d %H:%M")), contribfile)
+    append_to_file('\n', contribfile)
+
+    gitgrep = subprocess.check_output(['git', 'grep', 'author', '--', '*.geojson'])
+    authors = set(re.findall(r'"author": "(.*?)"', gitgrep))
+    for author in sorted(authors):
+        append_to_file(' * ' + author, contribfile)
+
+if __name__ == "__main__":
+    build_contrib_file()
+
+# vim: foldmethod=marker ai ts=4 sts=4 et sw=4 ft=python


### PR DESCRIPTION
We didn't cite our data source from http://www.marineregions.org/images/boundaries/IHO_crop.png.  This fixes this oversight. 

cc @akturner