### PR TITLE
Remove 360-degree shift from fix_features_at_prime_meridian.py

### DIFF
--- a/fix_features_at_antimeridian.py
+++ b/fix_features_at_antimeridian.py
@@ -4,9 +4,9 @@
 
 This script is used to split features that cross the antimeridian (+/-180 lon).
 The script reads from a single files containing the collection of features
-to be split at the antimeridian (the file can be 'features.geojson')
-and produces a file 'features.geojson'where all features are made up of
-polygons that do not cross the antimeridian.
+to be split at the antimeridian (the file can be the same as the output file)
+and produces a file indicated by the -o flag ('features.geojson' by default
+where all features are made up of polygons that do not cross the antimeridian.
 
 The code maps features into polar coordinates centered at the closest pole,
 which implicitly assumes that no segment of a feature will cover more than

--- a/fix_features_at_prime_meridian.py
+++ b/fix_features_at_prime_meridian.py
@@ -2,13 +2,14 @@
 
 """
 
-This script is used to split features across the prime meridian.  The 
+This script is used to split features across the prime meridian.  The
 features should not cross the antimeridian (+/-180 lon), so the user should
 call fix_features_at_antimeridian.py first if necessary before using this
-tool.  The script reads from a single files containing the collection of 
-features to be split at the prime meridian (the file can be 'features.geojson')
-and produces a file 'features.geojson' where all features are made up of
-polygons that do not cross the prime meridian.
+tool.  The script reads from a single files containing the collection of
+features to be split at the prime meridian (the file can be the same as the
+output file) and produces a file indicated by the -o flag ('features.geojson'
+by default) where all features are made up of polygons that do not cross the 
+prime meridian.
 
 The script makes use of the shapely library.
 
@@ -28,19 +29,19 @@ import shapely.affinity
 
 
 def splitGeometryCrossingPrimeMeridian(geometry):
-    
+
     primeMeridian = shapely.geometry.LineString([(0.,-90.),(0.,90.)])
     featureShape = shapely.geometry.shape(geometry)
 
     if(not featureShape.intersects(primeMeridian)):
         return
-  
+
     eastMask = shapely.geometry.Polygon([(0.,-90.),
                                          (180.,-90.),
                                          (180., 90.),
                                          (0., 90.),
                                          (0., -90.)])
-                                        
+
     westMask = shapely.geometry.Polygon([(-180.,-90.),
                                          (0.,-90.),
                                          (0., 90.),
@@ -51,7 +52,6 @@ def splitGeometryCrossingPrimeMeridian(geometry):
     print "  bounds before split:", featureShape.bounds
 
     westShape = featureShape.difference(eastMask)
-    westShape = shapely.affinity.translate(westShape, 360., 0.)
     print "  bounds of western half:", westShape.bounds
     eastShape = featureShape.difference(westMask)
     print "  bounds of eastern half:", eastShape.bounds


### PR DESCRIPTION
This merge removes an unnecessary shift by 360 degrees in the script fix_features_at_prime_meridian.py. This behavior was added for compatibility with the 0-360 degree longitude coordinate used in MPAS-O but is no longer needed because the mask creator supports features between -180 and 180 degrees longitude by default.