### PR TITLE
Add groupName as an attribute to merged feature files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /*.geojson
 /*.png
+*.pyc

--- a/combine_features.py
+++ b/combine_features.py
@@ -32,6 +32,9 @@ parser.add_argument("-f", "--feature_file", dest="feature_file",
 parser.add_argument("-n", "--new_feature_name", dest="new_feature_name",
                     help="The new name of the combined feature",
                     metavar="NAME", required=True)
+parser.add_argument("-g", "--groupName", dest="groupName",
+                    help="Feature group name.",
+                    metavar="GROUPNAME", default="unspecifiedGroupName")
 parser.add_argument("-o", "--output", dest="output_file_name",
                     help="Output file, e.g., features.geojson.",
                     metavar="PATH", default="features.geojson")
@@ -97,6 +100,7 @@ feature['properties']['author'] = '; '.join(list(set(authors)))
 feature['properties']['constituents'] = '; '.join(list(set(featureNames)))
 feature['geometry'] = shapely.geometry.mapping(combinedShape)
 features['features'].append(feature)
+features['groupName'] = args.groupName
 
 if feature['geometry']['type'] == 'GeometryCollection':
     print "Error: combined geometry from %s is of type GeometryCollection."%(args.feature_file)

--- a/difference_features.py
+++ b/difference_features.py
@@ -31,6 +31,9 @@ parser.add_argument("-m", "--mask_file", dest="mask_file",
                     help="Feature file with one or more features whose overlap "
                          "with features in feature_file should be removed",
                     metavar="FILE2", required=True)
+parser.add_argument("-g", "--groupName", dest="groupName",
+                    help="Feature group name.",
+                    metavar="GROUPNAME", default="unspecifiedGroupName")
 parser.add_argument("-o", "--output", dest="output_file_name",
                     help="Output file, e.g., features.geojson.",
                     metavar="PATH", default="features.geojson")
@@ -107,6 +110,8 @@ for feature in featuresToMask['features']:
         features['features'].append(feature)
     else:
         print "%s has been removed."%name
+
+features['groupName'] = args.groupName
 
 write_all_features(features, out_file_name, indent=4)
 

--- a/driver_scripts/setup_MOC_basins.py
+++ b/driver_scripts/setup_MOC_basins.py
@@ -19,6 +19,8 @@ parser.add_option("--plot", action="store_true", dest="plot")
 
 options, args = parser.parse_args()
 
+groupNameMOC = 'MOCBasinRegionsGroup'
+groupNameBasins = 'OceanBasinRegionsMOCGroup'
 
 subBasins = {'Atlantic': ['Atlantic', 'Mediterranean'],
              'IndoPacific': ['Pacific', 'Indian'],
@@ -52,11 +54,11 @@ for basinName in subBasins:
     #merge the the features into a single file
     print " * combining features into single feature named %s_MOC"%basinName
     spcall(['./combine_features.py', '-f', basinFileName, '-n', '%s_MOC'%basinName,
-            '-o', basinCombinedFileName])
+            '-g', groupNameBasins, '-o', basinCombinedFileName])
 
     print " * masking out features south of MOC region"
     spcall(['./difference_features.py', '-f', basinCombinedFileName,
-            '-m', MOCMaskFileNames[basinName], '-o', MOCName])
+            '-m', MOCMaskFileNames[basinName], '-g', groupNameMOC, '-o', MOCName])
 
     if options.plot:
         spcall(['./plot_features.py', '-f', MOCName, '-o', imageName, '-m', 'cyl'])

--- a/driver_scripts/setup_ocean_basins.py
+++ b/driver_scripts/setup_ocean_basins.py
@@ -18,6 +18,8 @@ parser.add_option("--plot", action="store_true", dest="plot")
 
 options, args = parser.parse_args()
 
+groupName = 'OceanBasinRegionsGroup'
+
 for oceanName in 'Atlantic', 'Pacific', 'Indian', 'Arctic', 'Southern_Ocean', 'Mediterranean':
 
     tag = '%s_Basin'%oceanName
@@ -37,7 +39,7 @@ for oceanName in 'Atlantic', 'Pacific', 'Indian', 'Arctic', 'Southern_Ocean', 'M
     #merge the the features into a single file
     print " * combining features into single feature named %s_Basin"%oceanName
     spcall(['./combine_features.py', '-f', basinFileNameName, '-n', '%s_Basin'%oceanName,
-            '-o', basinCombinedFileName])
+            '-g', groupName, '-o', basinCombinedFileName])
     
     if(options.plot):
         args = ['./plot_features.py', '-f', basinCombinedFileName, '-o', imageName, '-m', 'cyl']

--- a/merge_features.py
+++ b/merge_features.py
@@ -30,6 +30,7 @@ from utils.feature_test_utils import match_tag_list, feature_already_exists
 parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawTextHelpFormatter)
 parser.add_argument("-f", "--feature_file", dest="feature_file", help="Single feature file to append to features.geojson", metavar="FILE")
 parser.add_argument("-d", "--features_directory", dest="features_dir", help="Directory containing multiple feature files, each will be appended to features.geojson", metavar="PATH")
+parser.add_argument("-g", "--group", dest="groupName", help="Feature group name.", metavar="GROUPNAME", default="unspecifiedGroupName")
 parser.add_argument("-t", "--tags", dest="tags", help="Semicolon separated list of tags to match features against.", metavar='"TAG1;TAG2;TAG3"')
 parser.add_argument("-o", "--output", dest="output_file_name", help="Output file, e.g., features.geojson.", metavar="PATH", default="features.geojson")
 
@@ -100,6 +101,8 @@ if args.features_dir:
         except:
             print "Error parsing geojson file: %s"%(path)
     del paths
+
+all_features['groupName'] = args.groupName
 
 write_all_features(all_features, file_to_append, indent=4)
 


### PR DESCRIPTION
This merge adds groupName to the merged feature files, to allow feature
groups to be created by subsequent tools.

Fixes #65