### PR TITLE
Add 'seed_point' tag to all ocean points

### DIFF
--- a/ocean/point/Equatorial_Pacific_E145.0_N00.0/point.geojson
+++ b/ocean/point/Equatorial_Pacific_E145.0_N00.0/point.geojson
@@ -5,7 +5,7 @@
             "type": "Feature", 
             "properties": {
                 "name": "Equatorial_Pacific_E145.0_N00.0", 
-                "tags": "", 
+                "tags": "seed_point", 
                 "object": "point", 
                 "component": "ocean", 
                 "author": "Todd Ringler"

--- a/ocean/point/Equatorial_Pacific_E155.0_N00.0/point.geojson
+++ b/ocean/point/Equatorial_Pacific_E155.0_N00.0/point.geojson
@@ -5,7 +5,7 @@
             "type": "Feature", 
             "properties": {
                 "name": "Equatorial_Pacific_E155.0_N00.0", 
-                "tags": "", 
+                "tags": "seed_point", 
                 "object": "point", 
                 "component": "ocean", 
                 "author": "Todd Ringler"

--- a/ocean/point/Equatorial_Pacific_E165.0_N00.0/point.geojson
+++ b/ocean/point/Equatorial_Pacific_E165.0_N00.0/point.geojson
@@ -5,7 +5,7 @@
             "type": "Feature", 
             "properties": {
                 "name": "Equatorial_Pacific_E165.0_N00.0", 
-                "tags": "", 
+                "tags": "seed_point", 
                 "object": "point", 
                 "component": "ocean", 
                 "author": "Todd Ringler"

--- a/ocean/point/Equatorial_Pacific_E175.0_N00.0/point.geojson
+++ b/ocean/point/Equatorial_Pacific_E175.0_N00.0/point.geojson
@@ -5,7 +5,7 @@
             "type": "Feature", 
             "properties": {
                 "name": "Equatorial_Pacific_E175.0_N00.0", 
-                "tags": "", 
+                "tags": "seed_point", 
                 "object": "point", 
                 "component": "ocean", 
                 "author": "Todd Ringler"

--- a/ocean/point/Equatorial_Pacific_W090.0_N00.0/point.geojson
+++ b/ocean/point/Equatorial_Pacific_W090.0_N00.0/point.geojson
@@ -5,7 +5,7 @@
             "type": "Feature", 
             "properties": {
                 "name": "Equatorial_Pacific_W090.0_N00.0", 
-                "tags": "", 
+                "tags": "seed_point", 
                 "object": "point", 
                 "component": "ocean", 
                 "author": "Todd Ringler"

--- a/ocean/point/Equatorial_Pacific_W095.0_N00.0/point.geojson
+++ b/ocean/point/Equatorial_Pacific_W095.0_N00.0/point.geojson
@@ -5,7 +5,7 @@
             "type": "Feature", 
             "properties": {
                 "name": "Equatorial_Pacific_W095.0_N00.0", 
-                "tags": "", 
+                "tags": "seed_point", 
                 "object": "point", 
                 "component": "ocean", 
                 "author": "Todd Ringler"

--- a/ocean/point/Equatorial_Pacific_W105.0_N00.0/point.geojson
+++ b/ocean/point/Equatorial_Pacific_W105.0_N00.0/point.geojson
@@ -5,7 +5,7 @@
             "type": "Feature", 
             "properties": {
                 "name": "Equatorial_Pacific_W105.0_N00.0", 
-                "tags": "", 
+                "tags": "seed_point", 
                 "object": "point", 
                 "component": "ocean", 
                 "author": "Todd Ringler"

--- a/ocean/point/Equatorial_Pacific_W115.0_N00.0/point.geojson
+++ b/ocean/point/Equatorial_Pacific_W115.0_N00.0/point.geojson
@@ -5,7 +5,7 @@
             "type": "Feature", 
             "properties": {
                 "name": "Equatorial_Pacific_W115.0_N00.0", 
-                "tags": "", 
+                "tags": "seed_point", 
                 "object": "point", 
                 "component": "ocean", 
                 "author": "Todd Ringler"

--- a/ocean/point/Equatorial_Pacific_W125.0_N00.0/point.geojson
+++ b/ocean/point/Equatorial_Pacific_W125.0_N00.0/point.geojson
@@ -5,7 +5,7 @@
             "type": "Feature", 
             "properties": {
                 "name": "Equatorial_Pacific_W125.0_N00.0", 
-                "tags": "", 
+                "tags": "seed_point", 
                 "object": "point", 
                 "component": "ocean", 
                 "author": "Todd Ringler"

--- a/ocean/point/Equatorial_Pacific_W135.0_N00.0/point.geojson
+++ b/ocean/point/Equatorial_Pacific_W135.0_N00.0/point.geojson
@@ -5,7 +5,7 @@
             "type": "Feature", 
             "properties": {
                 "name": "Equatorial_Pacific_W135.0_N00.0", 
-                "tags": "", 
+                "tags": "seed_point", 
                 "object": "point", 
                 "component": "ocean", 
                 "author": "Todd Ringler"

--- a/ocean/point/Equatorial_Pacific_W145.0_N00.0/point.geojson
+++ b/ocean/point/Equatorial_Pacific_W145.0_N00.0/point.geojson
@@ -5,7 +5,7 @@
             "type": "Feature", 
             "properties": {
                 "name": "Equatorial_Pacific_W145.0_N00.0", 
-                "tags": "", 
+                "tags": "seed_point", 
                 "object": "point", 
                 "component": "ocean", 
                 "author": "Todd Ringler"

--- a/ocean/point/Equatorial_Pacific_W155.0_N00.0/point.geojson
+++ b/ocean/point/Equatorial_Pacific_W155.0_N00.0/point.geojson
@@ -5,7 +5,7 @@
             "type": "Feature", 
             "properties": {
                 "name": "Equatorial_Pacific_W155.0_N00.0", 
-                "tags": "", 
+                "tags": "seed_point", 
                 "object": "point", 
                 "component": "ocean", 
                 "author": "Todd Ringler"

--- a/ocean/point/Equatorial_Pacific_W155.0_N02.0/point.geojson
+++ b/ocean/point/Equatorial_Pacific_W155.0_N02.0/point.geojson
@@ -5,7 +5,7 @@
             "type": "Feature", 
             "properties": {
                 "name": "Equatorial_Pacific_W155.0_N02.0", 
-                "tags": "", 
+                "tags": "seed_point", 
                 "object": "point", 
                 "component": "ocean", 
                 "author": "Todd Ringler"

--- a/ocean/point/Equatorial_Pacific_W155.0_N04.0/point.geojson
+++ b/ocean/point/Equatorial_Pacific_W155.0_N04.0/point.geojson
@@ -5,7 +5,7 @@
             "type": "Feature", 
             "properties": {
                 "name": "Equatorial_Pacific_W155.0_N04.0", 
-                "tags": "", 
+                "tags": "seed_point", 
                 "object": "point", 
                 "component": "ocean", 
                 "author": "Todd Ringler"

--- a/ocean/point/Equatorial_Pacific_W155.0_N06.0/point.geojson
+++ b/ocean/point/Equatorial_Pacific_W155.0_N06.0/point.geojson
@@ -5,7 +5,7 @@
             "type": "Feature", 
             "properties": {
                 "name": "Equatorial_Pacific_W155.0_N06.0", 
-                "tags": "", 
+                "tags": "seed_point", 
                 "object": "point", 
                 "component": "ocean", 
                 "author": "Todd Ringler"

--- a/ocean/point/Equatorial_Pacific_W155.0_N08.0/point.geojson
+++ b/ocean/point/Equatorial_Pacific_W155.0_N08.0/point.geojson
@@ -5,7 +5,7 @@
             "type": "Feature", 
             "properties": {
                 "name": "Equatorial_Pacific_W155.0_N08.0", 
-                "tags": "", 
+                "tags": "seed_point", 
                 "object": "point", 
                 "component": "ocean", 
                 "author": "Todd Ringler"

--- a/ocean/point/Equatorial_Pacific_W155.0_N10.0/point.geojson
+++ b/ocean/point/Equatorial_Pacific_W155.0_N10.0/point.geojson
@@ -5,7 +5,7 @@
             "type": "Feature", 
             "properties": {
                 "name": "Equatorial_Pacific_W155.0_N10.0", 
-                "tags": "", 
+                "tags": "seed_point", 
                 "object": "point", 
                 "component": "ocean", 
                 "author": "Todd Ringler"

--- a/ocean/point/Equatorial_Pacific_W155.0_S02.0/point.geojson
+++ b/ocean/point/Equatorial_Pacific_W155.0_S02.0/point.geojson
@@ -5,7 +5,7 @@
             "type": "Feature", 
             "properties": {
                 "name": "Equatorial_Pacific_W155.0_S02.0", 
-                "tags": "", 
+                "tags": "seed_point", 
                 "object": "point", 
                 "component": "ocean", 
                 "author": "Todd Ringler"

--- a/ocean/point/Equatorial_Pacific_W155.0_S04.0/point.geojson
+++ b/ocean/point/Equatorial_Pacific_W155.0_S04.0/point.geojson
@@ -5,7 +5,7 @@
             "type": "Feature", 
             "properties": {
                 "name": "Equatorial_Pacific_W155.0_S04.0", 
-                "tags": "", 
+                "tags": "seed_point", 
                 "object": "point", 
                 "component": "ocean", 
                 "author": "Todd Ringler"

--- a/ocean/point/Equatorial_Pacific_W155.0_S06.0/point.geojson
+++ b/ocean/point/Equatorial_Pacific_W155.0_S06.0/point.geojson
@@ -5,7 +5,7 @@
             "type": "Feature", 
             "properties": {
                 "name": "Equatorial_Pacific_W155.0_S06.0", 
-                "tags": "", 
+                "tags": "seed_point", 
                 "object": "point", 
                 "component": "ocean", 
                 "author": "Todd Ringler"

--- a/ocean/point/Equatorial_Pacific_W155.0_S08.0/point.geojson
+++ b/ocean/point/Equatorial_Pacific_W155.0_S08.0/point.geojson
@@ -5,7 +5,7 @@
             "type": "Feature", 
             "properties": {
                 "name": "Equatorial_Pacific_W155.0_S08.0", 
-                "tags": "", 
+                "tags": "seed_point", 
                 "object": "point", 
                 "component": "ocean", 
                 "author": "Todd Ringler"

--- a/ocean/point/Equatorial_Pacific_W155.0_S10.0/point.geojson
+++ b/ocean/point/Equatorial_Pacific_W155.0_S10.0/point.geojson
@@ -5,7 +5,7 @@
             "type": "Feature", 
             "properties": {
                 "name": "Equatorial_Pacific_W155.0_S10.0", 
-                "tags": "", 
+                "tags": "seed_point", 
                 "object": "point", 
                 "component": "ocean", 
                 "author": "Todd Ringler"

--- a/ocean/point/Equatorial_Pacific_W165.0_N00.0/point.geojson
+++ b/ocean/point/Equatorial_Pacific_W165.0_N00.0/point.geojson
@@ -5,7 +5,7 @@
             "type": "Feature", 
             "properties": {
                 "name": "Equatorial_Pacific_W165.0_N00.0", 
-                "tags": "", 
+                "tags": "seed_point", 
                 "object": "point", 
                 "component": "ocean", 
                 "author": "Todd Ringler"

--- a/ocean/point/Equatorial_Pacific_W175.0_N00.0/point.geojson
+++ b/ocean/point/Equatorial_Pacific_W175.0_N00.0/point.geojson
@@ -5,7 +5,7 @@
             "type": "Feature", 
             "properties": {
                 "name": "Equatorial_Pacific_W175.0_N00.0", 
-                "tags": "", 
+                "tags": "seed_point", 
                 "object": "point", 
                 "component": "ocean", 
                 "author": "Todd Ringler"

--- a/ocean/point/Southern_Ocean_Drake_Passage_W070.0_S55.0/point.geojson
+++ b/ocean/point/Southern_Ocean_Drake_Passage_W070.0_S55.0/point.geojson
@@ -5,7 +5,7 @@
             "type": "Feature", 
             "properties": {
                 "name": "Southern_Ocean_Drake_Passage_W070.0_S55.0", 
-                "tags": "", 
+                "tags": "seed_point", 
                 "object": "point", 
                 "component": "ocean", 
                 "author": "Todd Ringler"

--- a/ocean/point/Southern_Ocean_Drake_Passage_W070.0_S60.0/point.geojson
+++ b/ocean/point/Southern_Ocean_Drake_Passage_W070.0_S60.0/point.geojson
@@ -5,7 +5,7 @@
             "type": "Feature", 
             "properties": {
                 "name": "Southern_Ocean_Drake_Passage_W070.0_S60.0", 
-                "tags": "", 
+                "tags": "seed_point", 
                 "object": "point", 
                 "component": "ocean", 
                 "author": "Todd Ringler"

--- a/ocean/point/Southern_Ocean_Drake_Passage_W070.0_S65.0/point.geojson
+++ b/ocean/point/Southern_Ocean_Drake_Passage_W070.0_S65.0/point.geojson
@@ -5,7 +5,7 @@
             "type": "Feature", 
             "properties": {
                 "name": "Southern_Ocean_Drake_Passage_W070.0_S65.0", 
-                "tags": "", 
+                "tags": "seed_point", 
                 "object": "point", 
                 "component": "ocean", 
                 "author": "Todd Ringler"


### PR DESCRIPTION
This tag is used to find seed points for the "flood fill" operation
used to make sure the ocean is a single, connected body when setting
up MPAS-Ocean `global_ocean` test cases.

Adding this tag will make it possible to add ocean points that are
not necessarily in the ocean domain for all model configurations.
For example, points below ice shelves would not be in the ocean
domain for setups without ice-shelf cavities.