### PR TITLE
Add standard transect sections

### DIFF
--- a/driver_scripts/setup_ocean_standard_transport_sections.py
+++ b/driver_scripts/setup_ocean_standard_transport_sections.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python
+
+"""
+This script creates region groups for the standard set of transport sections,
+all of which have the "standard_transport_sections" tag.
+
+Author: Xylar Asay-Davis
+"""
+
+import os
+import os.path
+import subprocess
+
+tag = 'standard_transport_sections'
+fileName = 'standard_transport_sections.geojson'
+groupName = 'StandardTransportSectionsRegionsGroup'
+    
+if os.path.exists(fileName):
+    os.remove(fileName)
+
+
+subprocess.check_call(['./merge_features.py',
+                       '-d', 'ocean/transect',
+                       '-t', tag,
+                       '-o', fileName])
+
+subprocess.check_call(['./set_group_name.py',
+                       '-f', fileName,
+                       '-g', groupName])
+
+# vim: foldmethod=marker ai ts=4 sts=4 et sw=4 ft=python

--- a/feature_creation_scripts/transport_transects/transport_sections.m
+++ b/feature_creation_scripts/transport_transects/transport_sections.m
@@ -1,0 +1,280 @@
+%function transport_sections
+
+% Specify data files, coordinates and text, then call functions
+% to find edge sections, load data, and compute transport through
+% each section.
+%
+% This script produces new netcdf files in the subdirectory
+% netcdf_files which can then be merged with grid.nc or restart.nc
+% files to collect transport data in MPAS-Ocean
+%
+% To merge the new *_section_edge_data.nc with an existing grid or
+% restart file, use:
+% ncks -A -v sectionEdgeIndex,sectionEdgeSign,nEdgesInSection,\
+% sectionText,sectionAbbreviation,sectionCoord \
+% your_file_section_edge_data.nc your_restart_file.nc
+%
+% Mark Petersen, MPAS-Ocean Team, LANL, March 2014
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%
+%  Specify data files
+%
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+% all plots are placed in the f directory.  Comment out if not needed.
+unix('mkdir -p f netcdf_files docs text_files');
+
+% The text string [wd '/' sim(i).dir '/' sim(i).netcdf_file ] is the file path,
+% where wd is the working directory and dir is the run directory.
+
+wd = '/var/tmp/mpeterse/runs/';
+dir='m91';
+abc = 'klmnop';
+
+for letter=1:length(abc)
+
+% These files only need to contain a small number of variables.
+% You may need to reduce the file size before copying to a local
+% machine using:
+% ncks -v avgNormalVelocity,avgNormalTransportVelocity,nAverage,latVertex,lonVertex,verticesOnEdge,edgesOnVertex,refLayerThickness,dvEdge \
+% file_in.nc file_out.nc
+
+clear sim
+for j=1:3
+  sim(j).dir=[dir abc(letter)];
+  sim(j).netcdf_file = ['output.00' num2str_fixed0(16+j,'%g',2) '-02-01_00.00.00.nc_transport_vars.nc'];
+end
+
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%
+%  Specify section coordinates and text
+%
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% sectionText        a cell array with text describing each section
+sectionText = {
+'Drake Passage, S Ocean -56  to -63 lat,  68W lon, section A21,  140+/- 6 Sv in Ganachaud_Wunsch00n and Ganachaud99thesis',...
+'Tasmania-Ant, S Ocean  -44  to -66 lat, 140E lon, section P12,  157+/-10 Sv in Ganachaud_Wunsch00n and Ganachaud99thesis',...
+'Africa-Ant, S Ocean    -31.3to -70 lat,  30E lon, section  I6,           Sv in Ganachaud99thesis                        ',...
+'Antilles Inflow, Carib.                                       -18.4+/-4.7Sv in Johns_ea02dsr                            '...
+'Mona Passage, Caribbian                                        -2.6+/-1.2Sv in Johns_ea02dsr                            '...
+'Windward Passage, Carib                                        -7.0      Sv in Nelepo_ea76sr, Roemmich81jgr             '...
+'Florida-Cuba, Caribbian                                        31.5+/-1.5Sv in Johns_ea02dsr, 32.3+/-3.2Sv Larsen92rslpt'...
+'Florida-Bahamas, Carib. 27 lat, -80  to -78.8lon,              31.5+/-1.5Sv in Johns_ea02dsr, 32.3+/-3.2Sv Larsen92rslpt'...
+'Indonesian Throughflow, -9  to -18 lat, 116E lon, section J89,  -16+/- 5 Sv in Ganachaud_Wunsch00n and Ganachaud99thesis',...
+'Agulhas                                                         -70+/-20 Sv in Bryden_Beal01dsr                         ',...
+'Mozambique Channel,    -25 lat,  35  to  44E lon, section I4 ,  -14+/- 6 Sv in Ganachaud_Wunsch00n and Ganachaud99thesis',...
+'Bering Strait, Arctic                                          0.83+/-0.66Sv in Roach_ea95jgr                           '...
+    };
+%'Lancaster Sound, Arctic                                        0.67+/-0.3Sv in Maltrud_McLean05om                       '...
+%'Fram Strait, Arctic                                           -4.2+/-2.3Sv in Fahrbach_ea01pr                           '...
+%'Robeson Channel, Arctic                                       -0.75+/-0.2Sv in Maltrud_McLean05om                       '...
+
+% sectionAbbreviation an 8-character title for each section
+sectionAbbreviation = [...
+    'Drake Pa';...
+    'Tasm-Ant';...
+    'Afri-Ant';...
+    'Antilles';...
+    'Mona Pas';...
+    'Wind Pas';...
+    'FL-Cuba ';...
+    'FL-Baham';...
+    'Ind Thru';...
+    'Agulhas ';...
+    'Mozam Ch';...
+    'Bering  ';...
+];
+%    'Lancastr';...
+%   'Fram    ';...
+%   'Robeson ';...
+
+% sectionCoord(nSections,4)  endpoints of sections, with one section per row as
+%   [startlat startlon endlat endlon]
+% Traverse from south to north, and from east to west.
+% Then positive velocities are eastward and northward.
+sectionCoord = [...
+ -64.5  -64    -55    -65.3;... % Drake
+ -67    140    -43.5  147  ;... % Tasm-Ant
+ -70.0   30    -31.3   30  ;... % Afri-Ant
+  10.7  -63.2   18.0  -65.9;... % Antilles  
+  18.4  -67.2   18.4  -68.5;... % Mona Passage
+  19.8  -73.4   20.1  -74.3;... % Windward Passage
+  23.1  -81.0   25.15 -81.0;... % Florida-Cuba
+  26.52 -78.78  26.7  -80.1;... % Florida-Bahamas
+ -21    116.0   -8.8  116  ;... % Ind Thru
+ -32.4   32.0  -31.0   30.2;... % Agulhas
+ -25     44.0  -25.0   34  ;... % Mozam Ch
+  65.8 -167.7   66.1 -169.7;... % Bering St
+  ];
+%  73.7  -80.6   74.6  -81.0;... % Lancaster Sound- was not able to
+%  get this to connect for all resolutions
+% 79.7   10.7   79.7  -17.7;... % Fram St - crosses 0 lon.  This is not in code yet.
+% 81.0  -63.5   82.0  -63.5;... % Robeson Ch - was not able to get this to connect 
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%
+%  Specify variables
+%
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+% var_name(nVars)    a cell array with text for each variable to
+%                    load or compute.
+% var_conv_factor    multiply each variable by this unit conversion.
+% var_lims(nVars,3)  contour line definition: min, max, interval 
+
+% Eulerian velocity from prognostic momentum equation
+var_name = {'avgNormalVelocity'};
+% total transport velocity
+%var_name = {'avgNormalTransportVelocity'}
+
+var_conv_factor = [1 1 1]; % No conversion here.
+
+var_lims = [-10 10 2.5; -10 10 2.5; 0 20 2.5];
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%
+%  Specify actions to be taken
+%
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+find_edge_sections_flag         = true ;
+write_edge_sections_text_flag   = false ;
+write_edge_sections_netcdf_flag = false ;
+plot_edge_sections_flag         = true ;
+compute_transport_flag          = true ;
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%
+%  Begin main code.  Normally this does not need to change.
+%
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%close all
+
+% change the coordinate range to be 0 to 360.
+sectionCoord(:,2) = mod(sectionCoord(:,2),360);
+sectionCoord(:,4) = mod(sectionCoord(:,4),360);
+
+for iSim = 1:length(sim)
+
+  fprintf(['**** simulation: ' sim(iSim).dir '  ' sim(iSim).netcdf_file '\n'])
+  unix(['mkdir -p docs/' sim(iSim).netcdf_file '_dir/f']);
+  fid_latex = fopen('temp.tex','w');
+  fprintf(fid_latex,['%% file created by plot_mpas_cross_sections, ' date '\n\n']);
+
+  %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+  %
+  %  Find edges that connect beginning and end points of section
+  %
+  %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+  if find_edge_sections_flag 
+    [sim(iSim).sectionEdgeIndex, sim(iSim).sectionEdgeSign, sim(iSim).nEdgesInSection, ...
+     sim(iSim).latSectionVertex,sim(iSim).lonSectionVertex, ...
+     sim(iSim).latVertexDeg,sim(iSim).lonVertexDeg] ...
+       = find_edge_sections(wd,sim(iSim).dir,sim(iSim).netcdf_file, ...
+       sectionText,sectionCoord);
+  end
+
+  %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+  %
+  %  Write section edge information to a netcdf file
+  %
+  %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+  if write_edge_sections_text_flag 
+    write_edge_sections_text...
+       (sim(iSim).dir, sim(iSim).sectionEdgeIndex, ...
+        sim(iSim).sectionEdgeSign, sim(iSim).nEdgesInSection, ...
+        sectionText,sectionAbbreviation,sectionCoord)
+  end
+  
+  if write_edge_sections_netcdf_flag 
+    write_edge_sections_netcdf...
+       (sim(iSim).dir, sim(iSim).sectionEdgeIndex, ...
+        sim(iSim).sectionEdgeSign, sim(iSim).nEdgesInSection, ...
+        sectionText,sectionAbbreviation,sectionCoord)
+  end
+
+  %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+  %
+  %  Plot edge section locations on world map
+  %
+  %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+  if plot_edge_sections_flag
+    sub_plot_edge_sections(sim(iSim).dir,sectionCoord, ...
+       sim(iSim).latSectionVertex,sim(iSim).lonSectionVertex, ...
+       sim(iSim).latVertexDeg,sim(iSim).lonVertexDeg, ...
+       sim(iSim).sectionEdgeIndex, sim(iSim).nEdgesInSection,...
+       fid_latex);
+  end
+
+  %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+  %
+  %  Load large variables from netcdf file
+  %
+  %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+  if compute_transport_flag
+    [sim(iSim).sectionData] = load_large_variables_edge ...
+       (wd,sim(iSim).dir,sim(iSim).netcdf_file, var_name,var_conv_factor, ...
+        sim(iSim).sectionEdgeIndex, sim(iSim).nEdgesInSection);
+  end
+  
+  %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+  %
+  %  Compute transport through each section
+  %
+  %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+  if compute_transport_flag
+    sim(iSim).tr_total = compute_transport ...
+     (wd,sim(iSim).dir,sim(iSim).netcdf_file, ...
+      sim(iSim).sectionEdgeIndex, sim(iSim).sectionEdgeSign, sim(iSim).nEdgesInSection, ...
+      sim(iSim).sectionData,sectionText,sectionAbbreviation);
+    
+    if iSim==1
+      tr_total = sim(iSim).tr_total';
+    else
+      tr_total = [tr_total; sim(iSim).tr_total'];
+    end
+    
+  end
+
+  fclose(fid_latex);
+  
+end % iSim
+
+% tr_total
+mean_transport = mean(tr_total,1);
+%fprintf(['mean over time, ' sim(1).dir ' \n' ])
+fprintf('%10.2f',mean_transport)
+fprintf([' mean, ' sim(1).dir ' \n'])
+
+var_transport = var(tr_total,1);
+%fprintf(['variance over time, ' sim(1).dir ' \n' ])
+fprintf('%10.2f',var_transport)
+fprintf([' var,  ' sim(1).dir ' \n'])
+
+std_transport = std(tr_total,1);
+%fprintf(['stdev over time, ' sim(1).dir ' \n' ])
+fprintf('%10.2f',std_transport)
+fprintf([' std,  ' sim(1).dir ' \n'])
+
+min_transport = min(tr_total,[],1);
+%fprintf(['minimum over time, ' sim(1).dir ' \n' ])
+fprintf('%10.2f',min_transport)
+fprintf([' min,  ' sim(1).dir ' \n'])
+
+max_transport = max(tr_total,[],1);
+%fprintf(['maximum over time, ' sim(1).dir ' \n' ])
+fprintf('%10.2f',max_transport)
+fprintf([' max,  ' sim(1).dir ' \n'])
+
+filename = ['data/' sim(1).dir '_' char(var_name) '_small_data_file.mat']
+clear sim
+save(filename)
+
+end % letter

--- a/ocean/transect/Africa-Ant/transect.geojson
+++ b/ocean/transect/Africa-Ant/transect.geojson
@@ -1,0 +1,30 @@
+{
+    "type": "FeatureCollection", 
+    "features": [
+        {
+            "type": "Feature", 
+            "properties": {
+                "name": "Africa-Ant", 
+                "tags": "standard_transport_sections", 
+                "object": "transect", 
+                "component": "ocean", 
+                "author": "Mark Petersen, Xylar Asay-Davis", 
+                "depth": "6000.0", 
+                "note": "S Ocean, -31.3to -70 lat, 30E lon, section I6, Sv in Ganachaud99thesis"
+            }, 
+            "geometry": {
+                "type": "LineString", 
+                "coordinates": [
+                    [
+                        30.000000, 
+                        -70.000000
+                    ], 
+                    [
+                        30.000000, 
+                        -31.300000
+                    ]
+                ]
+            }
+        }
+    ]
+}

--- a/ocean/transect/Agulhas/transect.geojson
+++ b/ocean/transect/Agulhas/transect.geojson
@@ -1,0 +1,30 @@
+{
+    "type": "FeatureCollection", 
+    "features": [
+        {
+            "type": "Feature", 
+            "properties": {
+                "name": "Agulhas", 
+                "tags": "standard_transport_sections", 
+                "object": "transect", 
+                "component": "ocean", 
+                "author": "Mark Petersen, Xylar Asay-Davis", 
+                "depth": "6000.0", 
+                "note": "-70+/-20 Sv in Bryden_Beal01dsr"
+            }, 
+            "geometry": {
+                "type": "LineString", 
+                "coordinates": [
+                    [
+                        32.000000, 
+                        -32.400000
+                    ], 
+                    [
+                        30.200000, 
+                        -31.000000
+                    ]
+                ]
+            }
+        }
+    ]
+}

--- a/ocean/transect/Antilles_Inflow/transect.geojson
+++ b/ocean/transect/Antilles_Inflow/transect.geojson
@@ -1,0 +1,30 @@
+{
+    "type": "FeatureCollection", 
+    "features": [
+        {
+            "type": "Feature", 
+            "properties": {
+                "name": "Antilles Inflow", 
+                "tags": "standard_transport_sections", 
+                "object": "transect", 
+                "component": "ocean", 
+                "author": "Mark Petersen, Xylar Asay-Davis", 
+                "depth": "6000.0", 
+                "note": "Carib., -18.4+/-4.7Sv in Johns_ea02dsr"
+            }, 
+            "geometry": {
+                "type": "LineString", 
+                "coordinates": [
+                    [
+                        -63.200000, 
+                        10.700000
+                    ], 
+                    [
+                        -65.900000, 
+                        18.000000
+                    ]
+                ]
+            }
+        }
+    ]
+}

--- a/ocean/transect/Bering_Strait/transect.geojson
+++ b/ocean/transect/Bering_Strait/transect.geojson
@@ -1,0 +1,30 @@
+{
+    "type": "FeatureCollection", 
+    "features": [
+        {
+            "type": "Feature", 
+            "properties": {
+                "name": "Bering Strait", 
+                "tags": "standard_transport_sections", 
+                "object": "transect", 
+                "component": "ocean", 
+                "author": "Mark Petersen, Xylar Asay-Davis", 
+                "depth": "6000.0", 
+                "note": "Arctic, 0.83+/-0.66Sv in Roach_ea95jgr"
+            }, 
+            "geometry": {
+                "type": "LineString", 
+                "coordinates": [
+                    [
+                        -167.700000, 
+                        65.800000
+                    ], 
+                    [
+                        -169.700000, 
+                        66.100000
+                    ]
+                ]
+            }
+        }
+    ]
+}

--- a/ocean/transect/Drake_Passage/transect.geojson
+++ b/ocean/transect/Drake_Passage/transect.geojson
@@ -1,0 +1,30 @@
+{
+    "type": "FeatureCollection", 
+    "features": [
+        {
+            "type": "Feature", 
+            "properties": {
+                "name": "Drake Passage", 
+                "tags": "standard_transport_sections", 
+                "object": "transect", 
+                "component": "ocean", 
+                "author": "Mark Petersen, Xylar Asay-Davis", 
+                "depth": "6000.0", 
+                "note": "S Ocean -56  to -63 lat, 68W lon, section A21, 140+/- 6 Sv in Ganachaud_Wunsch00n and Ganachaud99thesis"
+            }, 
+            "geometry": {
+                "type": "LineString", 
+                "coordinates": [
+                    [
+                        -63.000000, 
+                        -65.500000
+                    ], 
+                    [
+                        -67.000000, 
+                        -54.500000
+                    ]
+                ]
+            }
+        }
+    ]
+}

--- a/ocean/transect/Florida-Bahamas/transect.geojson
+++ b/ocean/transect/Florida-Bahamas/transect.geojson
@@ -1,0 +1,30 @@
+{
+    "type": "FeatureCollection", 
+    "features": [
+        {
+            "type": "Feature", 
+            "properties": {
+                "name": "Florida-Bahamas", 
+                "tags": "standard_transport_sections", 
+                "object": "transect", 
+                "component": "ocean", 
+                "author": "Mark Petersen, Xylar Asay-Davis", 
+                "depth": "6000.0", 
+                "note": "Carib., 27 lat, -80 to -78.8 lon, 31.5+/-1.5 Sv in Johns_ea02dsr, 32.3+/-3.2Sv Larsen92rslpt"
+            }, 
+            "geometry": {
+                "type": "LineString", 
+                "coordinates": [
+                    [
+                        -78.780000, 
+                        26.520000
+                    ], 
+                    [
+                        -80.100000, 
+                        26.700000
+                    ]
+                ]
+            }
+        }
+    ]
+}

--- a/ocean/transect/Florida-Cuba/transect.geojson
+++ b/ocean/transect/Florida-Cuba/transect.geojson
@@ -1,0 +1,30 @@
+{
+    "type": "FeatureCollection", 
+    "features": [
+        {
+            "type": "Feature", 
+            "properties": {
+                "name": "Florida-Cuba", 
+                "tags": "standard_transport_sections", 
+                "object": "transect", 
+                "component": "ocean", 
+                "author": "Mark Petersen, Xylar Asay-Davis", 
+                "depth": "6000.0", 
+                "note": "Caribbian, 31.5+/-1.5Sv in Johns_ea02dsr, 32.3+/-3.2Sv Larsen92rslpt"
+            }, 
+            "geometry": {
+                "type": "LineString", 
+                "coordinates": [
+                    [
+                        -81.000000, 
+                        23.100000
+                    ], 
+                    [
+                        -81.000000, 
+                        25.150000
+                    ]
+                ]
+            }
+        }
+    ]
+}

--- a/ocean/transect/Fram_Strait/transect.geojson
+++ b/ocean/transect/Fram_Strait/transect.geojson
@@ -1,0 +1,30 @@
+{
+    "type": "FeatureCollection", 
+    "features": [
+        {
+            "type": "Feature", 
+            "properties": {
+                "name": "Fram Strait", 
+                "tags": "standard_transport_sections", 
+                "object": "transect", 
+                "component": "ocean", 
+                "author": "Mark Petersen, Xylar Asay-Davis", 
+                "depth": "6000.0", 
+                "note": "Arctic, -4.2+/-2.3Sv in Fahrbach_ea01pr"
+            }, 
+            "geometry": {
+                "type": "LineString", 
+                "coordinates": [
+                    [
+                        10.700000, 
+                        79.700000
+                    ], 
+                    [
+                        -17.700000, 
+                        79.700000
+                    ]
+                ]
+            }
+        }
+    ]
+}

--- a/ocean/transect/Indonesian_Throughflow/transect.geojson
+++ b/ocean/transect/Indonesian_Throughflow/transect.geojson
@@ -1,0 +1,30 @@
+{
+    "type": "FeatureCollection", 
+    "features": [
+        {
+            "type": "Feature", 
+            "properties": {
+                "name": "Indonesian Throughflow", 
+                "tags": "standard_transport_sections", 
+                "object": "transect", 
+                "component": "ocean", 
+                "author": "Mark Petersen, Xylar Asay-Davis", 
+                "depth": "6000.0", 
+                "note": "-9 to -18 lat, 116E lon, section J89, -16+/- 5 Sv in Ganachaud_Wunsch00n and Ganachaud99thesis"
+            }, 
+            "geometry": {
+                "type": "LineString", 
+                "coordinates": [
+                    [
+                        116.000000, 
+                        -21
+                    ], 
+                    [
+                        116.000000, 
+                        -8.800000
+                    ]
+                ]
+            }
+        }
+    ]
+}

--- a/ocean/transect/Lancaster_Sound/transect.geojson
+++ b/ocean/transect/Lancaster_Sound/transect.geojson
@@ -1,0 +1,30 @@
+{
+    "type": "FeatureCollection", 
+    "features": [
+        {
+            "type": "Feature", 
+            "properties": {
+                "name": "Lancaster Sound", 
+                "tags": "standard_transport_sections", 
+                "object": "transect", 
+                "component": "ocean", 
+                "author": "Mark Petersen, Xylar Asay-Davis", 
+                "depth": "6000.0", 
+                "note": "Arctic, 0.67+/-0.3Sv in Maltrud_McLean05om"
+            }, 
+            "geometry": {
+                "type": "LineString", 
+                "coordinates": [
+                    [
+                        -80.600000, 
+                        73.700000
+                    ], 
+                    [
+                        -81.000000, 
+                        74.600000
+                    ]
+                ]
+            }
+        }
+    ]
+}

--- a/ocean/transect/Mona_Passage/transect.geojson
+++ b/ocean/transect/Mona_Passage/transect.geojson
@@ -1,0 +1,30 @@
+{
+    "type": "FeatureCollection", 
+    "features": [
+        {
+            "type": "Feature", 
+            "properties": {
+                "name": "Mona Passage", 
+                "tags": "standard_transport_sections", 
+                "object": "transect", 
+                "component": "ocean", 
+                "author": "Mark Petersen, Xylar Asay-Davis", 
+                "depth": "6000.0", 
+                "note": "Caribbian, -2.6+/-1.2Sv in Johns_ea02dsr"
+            }, 
+            "geometry": {
+                "type": "LineString", 
+                "coordinates": [
+                    [
+                        -67.200000, 
+                        18.400000
+                    ], 
+                    [
+                        -68.500000, 
+                        18.400000
+                    ]
+                ]
+            }
+        }
+    ]
+}

--- a/ocean/transect/Mozambique_Channel/transect.geojson
+++ b/ocean/transect/Mozambique_Channel/transect.geojson
@@ -1,0 +1,30 @@
+{
+    "type": "FeatureCollection", 
+    "features": [
+        {
+            "type": "Feature", 
+            "properties": {
+                "name": "Mozambique Channel", 
+                "tags": "standard_transport_sections", 
+                "object": "transect", 
+                "component": "ocean", 
+                "author": "Mark Petersen, Xylar Asay-Davis", 
+                "depth": "6000.0", 
+                "note": "-25 lat, 35 to 44E lon, section I4 , -14+/- 6 Sv in Ganachaud_Wunsch00n and Ganachaud99thesis"
+            }, 
+            "geometry": {
+                "type": "LineString", 
+                "coordinates": [
+                    [
+                        44.000000, 
+                        -25.000000
+                    ], 
+                    [
+                        34.000000, 
+                        -25.000000
+                    ]
+                ]
+            }
+        }
+    ]
+}

--- a/ocean/transect/Robeson_Channel/transect.geojson
+++ b/ocean/transect/Robeson_Channel/transect.geojson
@@ -1,0 +1,30 @@
+{
+    "type": "FeatureCollection", 
+    "features": [
+        {
+            "type": "Feature", 
+            "properties": {
+                "name": "Robeson Channel", 
+                "tags": "standard_transport_sections", 
+                "object": "transect", 
+                "component": "ocean", 
+                "author": "Mark Petersen, Xylar Asay-Davis", 
+                "depth": "6000.0", 
+                "note": "Arctic, -0.75+/-0.2Sv in Maltrud_McLean05om"
+            }, 
+            "geometry": {
+                "type": "LineString", 
+                "coordinates": [
+                    [
+                        -63.500000, 
+                        81.000000
+                    ], 
+                    [
+                        -63.500000, 
+                        82.000000
+                    ]
+                ]
+            }
+        }
+    ]
+}

--- a/ocean/transect/Tasmania-Ant/transect.geojson
+++ b/ocean/transect/Tasmania-Ant/transect.geojson
@@ -1,0 +1,30 @@
+{
+    "type": "FeatureCollection", 
+    "features": [
+        {
+            "type": "Feature", 
+            "properties": {
+                "name": "Tasmania-Ant", 
+                "tags": "standard_transport_sections", 
+                "object": "transect", 
+                "component": "ocean", 
+                "author": "Mark Petersen, Xylar Asay-Davis", 
+                "depth": "6000.0", 
+                "note": "S Ocean, -44 to -66 lat, 140E lon, section P12, 157+/-10 Sv in Ganachaud_Wunsch00n and Ganachaud99thesis"
+            }, 
+            "geometry": {
+                "type": "LineString", 
+                "coordinates": [
+                    [
+                        140, 
+                        -67
+                    ], 
+                    [
+                        147, 
+                        -43.500000
+                    ]
+                ]
+            }
+        }
+    ]
+}

--- a/ocean/transect/Windward_Passage/transect.geojson
+++ b/ocean/transect/Windward_Passage/transect.geojson
@@ -1,0 +1,30 @@
+{
+    "type": "FeatureCollection", 
+    "features": [
+        {
+            "type": "Feature", 
+            "properties": {
+                "name": "Windward Passage", 
+                "tags": "standard_transport_sections", 
+                "object": "transect", 
+                "component": "ocean", 
+                "author": "Mark Petersen, Xylar Asay-Davis", 
+                "depth": "6000.0", 
+                "note": "Carib,-7.0 Sv in Nelepo_ea76sr, Roemmich81jgr"
+            }, 
+            "geometry": {
+                "type": "LineString", 
+                "coordinates": [
+                    [
+                        -73.400000, 
+                        19.800000
+                    ], 
+                    [
+                        -74.300000, 
+                        20.100000
+                    ]
+                ]
+            }
+        }
+    ]
+}


### PR DESCRIPTION
Also adds a script that was originally used to create the sections (for provenance) and a driver script for merging the features together into a region group based on their common tag.