### PR TITLE
Add English Channel Deepen

### DIFF
--- a/ocean/transect/English_Channel_Deepen/transect.geojson
+++ b/ocean/transect/English_Channel_Deepen/transect.geojson
@@ -1,0 +1,29 @@
+{
+    "type": "FeatureCollection", 
+    "features": [
+        {
+            "type": "Feature", 
+            "properties": {
+                "name": "Red Sea Deepen", 
+                "tags": "Red_Sea_Deepen;Critical_Passage", 
+                "object": "transect", 
+                "component": "ocean", 
+                "author": "Xylar Asay-Davis", 
+                "depth": "200.0"
+            }, 
+            "geometry": {
+                "type": "LineString", 
+                "coordinates": [
+                    [
+                        42.484131, 
+                        14.157882
+                    ], 
+                    [
+                        44.132080, 
+                        11.480025
+                    ]
+                ]
+            }
+        }
+    ]
+}

--- a/ocean/transect/English_Channel_Deepen/transect.geojson
+++ b/ocean/transect/English_Channel_Deepen/transect.geojson
@@ -9,7 +9,7 @@
                 "object": "transect",
                 "component": "ocean",
                 "author": "Mark Petersen",
-                "depth": "15.0"
+                "depth": "120.0"
             },
             "geometry": {
                 "type": "LineString",

--- a/ocean/transect/English_Channel_Deepen/transect.geojson
+++ b/ocean/transect/English_Channel_Deepen/transect.geojson
@@ -1,27 +1,23 @@
 {
-    "type": "FeatureCollection", 
+    "type": "FeatureCollection",
     "features": [
         {
-            "type": "Feature", 
+            "type": "Feature",
             "properties": {
-                "name": "Red Sea Deepen", 
-                "tags": "Red_Sea_Deepen;Critical_Passage", 
-                "object": "transect", 
-                "component": "ocean", 
-                "author": "Xylar Asay-Davis", 
-                "depth": "200.0"
-            }, 
+                "name": "English Channel Deepen",
+                "tags": "English_Channel_Deepen;Critical_Passage",
+                "object": "transect",
+                "component": "ocean",
+                "author": "Mark Petersen",
+                "depth": "15.0"
+            },
             "geometry": {
-                "type": "LineString", 
+                "type": "LineString",
                 "coordinates": [
-                    [
-                        42.484131, 
-                        14.157882
-                    ], 
-                    [
-                        44.132080, 
-                        11.480025
-                    ]
+                    [ -5.0, 49.4],
+                    [ -2.0, 50.0],
+                    [  0.0, 50.2],
+                    [  2.2, 51.5]
                 ]
             }
         }


### PR DESCRIPTION
When creating the V3 mesh, the English Channel was closed on the
EC60to30 mesh. I drew a line by hand through the middle of the English
Channel. This version was used to make the current EC60to30V3 mesh, so
really needs to be in this geometric features repo with these points.

Note that the middle commit with 15m was used for the meshes made in
spring of 2017.  We changed it to 120m here to be more realistic.