### PR TITLE
Add Baja California critical blockage

### DIFF
--- a/geometric_data/ocean/transect/Baja_CA_blockage/transect.geojson
+++ b/geometric_data/ocean/transect/Baja_CA_blockage/transect.geojson
@@ -4,8 +4,8 @@
         {
             "type": "Feature", 
             "properties": {
-                "name": "Baja California", 
-                "tags": "Baja_California;Critical_Land_Blockage", 
+                "name": "Baja CA blockage", 
+                "tags": "Baja_CA_blockage;Critical_Land_Blockage", 
                 "object": "transect", 
                 "component": "ocean", 
                 "author": "Mark Petersen", 

--- a/geometric_data/ocean/transect/Baja_CA_blockage/transect.geojson
+++ b/geometric_data/ocean/transect/Baja_CA_blockage/transect.geojson
@@ -1,0 +1,53 @@
+{
+    "type": "FeatureCollection", 
+    "features": [
+        {
+            "type": "Feature", 
+            "properties": {
+                "name": "Baja California", 
+                "tags": "Baja_California;Critical_Land_Blockage", 
+                "object": "transect", 
+                "component": "ocean", 
+                "author": "Mark Petersen", 
+                "height": "100.0"
+            }, 
+            "geometry": {
+                "type": "LineString", 
+                "coordinates": [
+                    [
+                        -116.0,
+                          32.0
+                    ], 
+                    [
+                        -115.0,
+                          30.0
+                    ], 
+                    [
+                        -114.0,
+                          29.0
+                    ], 
+                    [
+                        -113.5,
+                          28.0
+                    ], 
+                    [
+                        -112.5,
+                          27.0
+                    ], 
+                    [
+                        -111.7,
+                          26.0
+                    ], 
+                    [
+                        -111.5,
+                          25.0
+                    ], 
+                    [
+                        -110.0,
+                          23.5
+                    ]
+                ]
+            }
+        }
+    ]
+}

--- a/geometric_features/features_and_tags.json
+++ b/geometric_features/features_and_tags.json
@@ -1451,6 +1451,10 @@
       "Antilles Inflow": [
         "standard_transport_sections"
       ],
+      "Baja CA blockage": [
+        "Baja_CA_blockage",
+        "Critical_Land_Blockage"
+      ],
       "Baltic Sea Deepen": [
         "Baltic_Sea_Deepen",
         "Critical_Passage"


### PR DESCRIPTION
In some low-resolution meshes, we can get a hole through Baja. This will prevent that.