### PR TITLE
fix matplotlib import when no xwindows

### DIFF
--- a/geometric_features/__main__.py
+++ b/geometric_features/__main__.py
@@ -3,12 +3,6 @@ from __future__ import absolute_import, division, print_function, \
 
 import argparse
 import os
-
-# make sure to set the Agg backend that works even without x-forwarding
-# before any other matplotlib imports
-import matplotlib as mpl
-mpl.use('Agg')
-
 import geometric_features
 from geometric_features import GeometricFeatures
 from geometric_features.feature_collection import FeatureCollection, \

--- a/geometric_features/feature_collection.py
+++ b/geometric_features/feature_collection.py
@@ -3,10 +3,17 @@ from __future__ import absolute_import, division, print_function, \
 
 import json
 from collections import OrderedDict
+try:
+    import matplotlib.pyplot as plt
+except ImportError:
+    # maybe no xwindows, so let's use the 'Agg' backend
+    import matplotlib as mpl
+    mpl.use('Agg', warn=False, force=True)
+    import matplotlib.pyplot as plt
+
 import shapely.geometry
 import shapely.ops
 import cartopy
-import matplotlib.pyplot as plt
 import numpy as np
 import progressbar
 import copy


### PR DESCRIPTION
Previous attempts to fix this didn't work out but this fix does seem to fix the tests.