### PR TITLE
Add missing 'type' key to combined features

### DIFF
--- a/geometric_features/feature_collection.py
+++ b/geometric_features/feature_collection.py
@@ -220,6 +220,7 @@ class FeatureCollection(object):
                                  geometry['type']))
 
         feature = {}
+        feature['type'] = 'Feature'
         feature['properties'] = {}
         feature['properties']['name'] = featureName
         feature['properties']['component'] = \


### PR DESCRIPTION
Without this dictionary entry, the resulting feature is not recognized, e.g., by geojsion.io.