### PR TITLE
Add GEOMETRIC_DATA_DIR environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,29 @@ found in the `examples` directory.  Each of the classes and functions that make
 up the package have extensive documentation.  More user-level documentation
 will be added shortly.
 
-To use `geometric_features`, it is highly recommended that you use an
-`anaconda` python environment.  Here is how to create and activate an
-environment with all of the required dependencies:
+To use geometric features, you can install it in a conda environment:
+```bash
+conda create -n geometric_features -c conda-forge python=3.7 geometric_features
+conda activate geometric_features
+```
+By default, `geometric_features` will download the data it needs on the fly.
+Since some of the features are quite large, this can be convenient if disk
+space is at a premium.
+
+Some systems do not support downloading the data (e.g. because of firewalls or
+compute nodes that don't have internet access.  In such cases, it is convenient
+to install `geometric_features` including all the data:
+```bash
+conda create -n geometric_features -c conda-forge python=3.7 \
+    "geometric_features=*=*with_data*"
+conda activate geometric_features
+```
+This syntax is admittedly a bit clunky but it selects for a special build of
+the conda package with the data included.
+
+To develop `geometric_features` (e.g. to add new features), it is highly
+recommended that you use an `anaconda` python environment.  Here is how to
+create and activate an environment with all of the required dependencies:
 ```bash
 conda create -n geometric_features -c conda-forge python=3.7 numpy matplotlib \
     cartopy shapely requests progressbar2

--- a/geometric_features/geometric_features.py
+++ b/geometric_features/geometric_features.py
@@ -34,15 +34,16 @@ class GeometricFeatures(object):
     # -------
     # Xylar Asay-Davis
 
-    def __init__(self, cacheLocation='./geometric_data',
-                 remoteBranchOrTag=None):
+    def __init__(self, cacheLocation=None, remoteBranchOrTag=None):
         '''
         The constructor for the GeometricFeatures object
 
         Parameters
         ----------
         cacheLocation : str, optional
-            The location of the local geometric features cache
+            The location of the local geometric features cache.  If not
+            specified, the environment variable ``$GEOMETRIC_DATA_DIR`` is
+            used if it is set and ``./geometric_data`` is used otherwise.
 
         remoteBranchOrTag : str, optional
             The branch or tag from the ``geometric_features`` repo to download
@@ -50,7 +51,13 @@ class GeometricFeatures(object):
             a tag the same as this version of ``geometric_features``
         '''
 
-        self.cacheLocation = cacheLocation
+        if cacheLocation is None:
+            if 'GEOMETRIC_DATA_DIR' in os.environ:
+                self.cacheLocation = os.environ['GEOMETRIC_DATA_DIR']
+            else:
+                self.cacheLocation = './geometric_data'
+        else:
+            self.cacheLocation = cacheLocation
         if remoteBranchOrTag is None:
             self.remoteBranch = geometric_features.__version__
         else:


### PR DESCRIPTION
This is the default location to look for geometric data if it is set.  The ability to set this variable will enable optionally packaging the data with the conda package.