### PR TITLE
Add Black Sea blockage

### DIFF
--- a/geometric_data/ocean/transect/Black_Sea_Blockage/transect.geojson
+++ b/geometric_data/ocean/transect/Black_Sea_Blockage/transect.geojson
@@ -1,0 +1,37 @@
+{
+    "type": "FeatureCollection",
+    "features": [
+        {
+            "type": "Feature",
+            "properties": {
+                "name": "Black Sea Blockage",
+                "tags": "Black_Sea_Blockage;Critical_Land_Blockage",
+                "object": "transect",
+                "component": "ocean",
+                "author": "Xylar",
+                "height": "100.0"
+            },
+            "geometry": {
+                "type": "LineString",
+                "coordinates": [
+                    [
+                        28.092041,
+                        41.360319
+                    ],
+                    [
+                        28.718262,
+                        41.186922
+                    ],
+                    [
+                        29.479065,
+                        41.037931
+                    ],
+                    [
+                        30.149231,
+                        40.957086
+                    ]
+                ]
+            }
+        }
+    ]
+}

--- a/geometric_features/__init__.py
+++ b/geometric_features/__init__.py
@@ -6,5 +6,5 @@ from geometric_features.geometric_features import GeometricFeatures
 from geometric_features.feature_collection import FeatureCollection, \
      read_feature_collection
 
-__version_info__ = (0, 1, 6)
+__version_info__ = (0, 1, 7)
 __version__ = '.'.join(str(vi) for vi in __version_info__)

--- a/geometric_features/features_and_tags.json
+++ b/geometric_features/features_and_tags.json
@@ -1526,6 +1526,10 @@
       "Bering Strait": [
         "standard_transport_sections"
       ],
+      "Black Sea Blockage": [
+        "Black_Sea_Blockage",
+        "Critical_Land_Blockage"
+      ],
       "Davis Strait": [
         "standard_transport_sections"
       ],

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "geometric_features" %}
-{% set version = "0.1.6" %}
-{% set build = 1 %}
+{% set version = "0.1.7" %}
+{% set build = 0 %}
 
 {% if with_data != "True" %}
 # prioritize no data via build number


### PR DESCRIPTION
This feature makes sure that the Black Sea is not included in MPAS meshes (as long as they use critical passages and critical land blockages, which high resolution meshes typically do not).