### PR TITLE
Add versions page do docs

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -23,3 +23,9 @@ Indices and tables
 
 * :ref:`genindex`
 
+Versions
+========
+.. toctree::
+   :maxdepth: 1
+
+   versions

--- a/docs/versions.rst
+++ b/docs/versions.rst
@@ -1,0 +1,14 @@
+Versions
+========
+
+================ ===============
+Documentation    On GitHub
+================ ===============
+`stable`_        `master`_
+`v0.1.7`_        `0.1.7`_
+================ ===============
+
+.. _`stable`: ../stable/index.html
+.. _`v0.1.7`: ../0.1.7/index.html
+.. _`master`: https://github.com/MPAS-Dev/geometric_features/tree/master
+.. _`0.1.7`: https://github.com/MPAS-Dev/geometric_features/tree/0.1.7


### PR DESCRIPTION
Now that we have separate docs for 0.1.7, it makes sense to have a link to it.  From now on, adding a link like this should be part of every release.