### PR TITLE
Fix merge_features to use package data by default

### DIFF
--- a/docs/versions.rst
+++ b/docs/versions.rst
@@ -6,9 +6,12 @@ Documentation    On GitHub
 ================ ===============
 `stable`_        `master`_
 `v0.1.7`_        `0.1.7`_
+`v0.1.8`_        `0.1.8`_
 ================ ===============
 
 .. _`stable`: ../stable/index.html
-.. _`v0.1.7`: ../0.1.7/index.html
 .. _`master`: https://github.com/MPAS-Dev/geometric_features/tree/master
+.. _`v0.1.7`: ../0.1.7/index.html
 .. _`0.1.7`: https://github.com/MPAS-Dev/geometric_features/tree/0.1.7
+.. _`v0.1.8`: ../0.1.8/index.html
+.. _`0.1.8`: https://github.com/MPAS-Dev/geometric_features/tree/0.1.8

--- a/geometric_features/__init__.py
+++ b/geometric_features/__init__.py
@@ -6,5 +6,5 @@ from geometric_features.geometric_features import GeometricFeatures
 from geometric_features.feature_collection import FeatureCollection, \
      read_feature_collection
 
-__version_info__ = (0, 1, 7)
+__version_info__ = (0, 1, 8)
 __version__ = '.'.join(str(vi) for vi in __version_info__)

--- a/geometric_features/__main__.py
+++ b/geometric_features/__main__.py
@@ -123,7 +123,7 @@ def merge_features():
                         metavar="PATH", default="features.geojson")
     parser.add_argument("--cache", dest="cache_location",
                         help="Location of local geometric_data cache.",
-                        metavar="PATH", default="./geometric_data")
+                        metavar="PATH")
     parser.add_argument('-v', '--version',
                         action='version',
                         version='geometric_features {}'.format(

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "geometric_features" %}
-{% set version = "0.1.7" %}
+{% set version = "0.1.8" %}
 {% set build = 0 %}
 
 {% if with_data != "True" %}


### PR DESCRIPTION
Previously, `merge_features` was using `./geometric_data` as the default geometry cache.  But with change to supporting a conda package version with the data included, the default is changed to the package's version of the data if available and `./geometric_data` only if not.  Thus, data is not downloaded if it is already available.

Update to v0.1.8. 