### PR TITLE
Only print info on masked features if requested

### DIFF
--- a/geometric_features/feature_collection.py
+++ b/geometric_features/feature_collection.py
@@ -307,9 +307,9 @@ class FeatureCollection(object):
         if show_progress:
             bar.finish()
 
-        print('  {} features unchanged, {} masked and {} dropped.'.format(
-            featureCount - maskedCount - droppedCount, maskedCount,
-            droppedCount))
+            print('  {} features unchanged, {} masked and {} dropped.'.format(
+                featureCount - maskedCount - droppedCount, maskedCount,
+                droppedCount))
 
         fc = FeatureCollection(maskedFeatures, self.otherProperties)
         return fc


### PR DESCRIPTION
The output is confusing if there is no context, so it has been removed unless `show_progress = True`.