### PR TITLE
 Add Atlantic MOC without Mediterranean

### DIFF
--- a/docs/versions.rst
+++ b/docs/versions.rst
@@ -15,6 +15,7 @@ Documentation    On GitHub
 `v0.2.0`_        `0.2.0`_
 `v0.3.0`_        `0.3.0`_
 `v0.4.0`_        `0.4.0`_
+`v0.5.0`_        `0.5.0`_
 ================ ===============
 
 .. _`stable`: ../stable/index.html
@@ -39,3 +40,5 @@ Documentation    On GitHub
 .. _`0.3.0`: https://github.com/MPAS-Dev/geometric_features/tree/0.3.0
 .. _`v0.4.0`: ../0.4.0/index.html
 .. _`0.4.0`: https://github.com/MPAS-Dev/geometric_features/tree/0.4.0
+.. _`v0.5.0`: ../0.5.0/index.html
+.. _`0.5.0`: https://github.com/MPAS-Dev/geometric_features/tree/0.5.0

--- a/geometric_features/__init__.py
+++ b/geometric_features/__init__.py
@@ -13,5 +13,5 @@ from geometric_features.__main__ import combine_features, difference_features, \
 from geometric_features.utils import write_feature_names_and_tags
 
 
-__version_info__ = (0, 4, 0)
+__version_info__ = (0, 5, 0)
 __version__ = '.'.join(str(vi) for vi in __version_info__)

--- a/geometric_features/aggregation/__init__.py
+++ b/geometric_features/aggregation/__init__.py
@@ -54,7 +54,7 @@ def get_aggregator_by_name(region_group):
                                   'date': '20210201',
                                   'function': ismip6},
                'MOC Basins': {'prefix': 'mocBasins',
-                              'date': '20210331',
+                              'date': '20210623',
                               'function': moc},
                'Transport Transects': {'prefix': 'transportTransects',
                                        'date': '20210323',

--- a/geometric_features/aggregation/ocean/moc_basins.py
+++ b/geometric_features/aggregation/ocean/moc_basins.py
@@ -24,12 +24,14 @@ def moc(gf):
     # -------
     # Xylar Asay-Davis
 
-    MOCSubBasins = {'Atlantic': ['Atlantic', 'Mediterranean'],
+    MOCSubBasins = {'Atlantic': ['Atlantic'],
+                    'AtlanticMed': ['Atlantic', 'Mediterranean'],
                     'IndoPacific': ['Pacific', 'Indian'],
                     'Pacific': ['Pacific'],
                     'Indian': ['Indian']}
 
     MOCSouthernBoundary = {'Atlantic': '34S',
+                           'AtlanticMed': '34S',
                            'IndoPacific': '34S',
                            'Pacific': '6S',
                            'Indian': '6S'}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "geometric_features" %}
-{% set version = "0.4.0" %}
+{% set version = "0.5.0" %}
 {% set build = 0 %}
 
 package:


### PR DESCRIPTION
This is the new default "Atlantic" MOC region, and the version
that includes the Mediterranean is now "AtlanticMed".

This merge updates the date stamp for the `mocBasins` aggregator
to today's date.

This merge also updates the `geometric_features` version number to 0.5.0, in anticipation of a release immediately after this PR.