### PR TITLE
Replace cascaded_union with unary_union

### DIFF
--- a/examples/setup_ocean_region_groups.py
+++ b/examples/setup_ocean_region_groups.py
@@ -213,7 +213,7 @@ def remove_small_polygons(fc, minArea):
                     else:
                         removedCount += 1
                 if len(outPolygons) > 0:
-                    outShape = shapely.ops.cascaded_union(outPolygons)
+                    outShape = shapely.ops.unary_union(outPolygons)
                     feature['geometry'] = shapely.geometry.mapping(outShape)
                     add = True
         if add:

--- a/feature_creation_scripts/extract_bedmachine_coastlines/extract_bedmachine_coastlines.py
+++ b/feature_creation_scripts/extract_bedmachine_coastlines/extract_bedmachine_coastlines.py
@@ -8,7 +8,7 @@ import matplotlib.pyplot as plt
 from skimage import measure
 
 from shapely.geometry import Polygon, mapping
-from shapely.ops import cascaded_union
+from shapely.ops import unary_union
 
 from geometric_features import FeatureCollection, GeometricFeatures, \
     read_feature_collection
@@ -138,7 +138,7 @@ def extract_geometry(mask):
         else:
             print("invalid shape with {} vertices".format(contour.shape[0]))
 
-    return mapping(cascaded_union(polys))
+    return mapping(unary_union(polys))
 
 
 out_file_name = "AntarcticIceCoverage.geojson"

--- a/feature_creation_scripts/extract_bedmap2_ice_coverage/extract_bedmap2_ice_coverage.py
+++ b/feature_creation_scripts/extract_bedmap2_ice_coverage/extract_bedmap2_ice_coverage.py
@@ -4,7 +4,7 @@ from matplotlib import pyplot
 from matplotlib import _cntr as cntr
 
 from shapely.geometry import Polygon, mapping
-from shapely.ops import cascaded_union
+from shapely.ops import unary_union
 
 from utils.feature_write_utils import write_all_features
 
@@ -56,10 +56,10 @@ def extract_geometry(mask):
             lats.insert(outIndex+1,newLat[i])
             outIndex += 1
 
-        print x0, x1, frac
-        print ys[inIndex], ys[inIndex+1], yMid
-        print lats[outIndex-5:outIndex+2], latMid
-        print lons[outIndex-5:outIndex+2]
+        print(x0, x1, frac)
+        print(ys[inIndex], ys[inIndex+1], yMid)
+        print(lats[outIndex-5:outIndex+2], latMid)
+        print(lons[outIndex-5:outIndex+2])
         pyplot.figure(1)
         pyplot.plot(xs,ys)
         pyplot.figure(2)
@@ -72,12 +72,12 @@ def extract_geometry(mask):
     floatMask = 2.*floatMask - 1.
 
     distance = skfmm.distance(floatMask)
-    print name, 'distance', numpy.amin(distance), numpy.amax(distance)
+    print(name, 'distance', numpy.amin(distance), numpy.amax(distance))
     pyplot.imsave('%s_distance.png'%name, distance, vmin=-1., vmax=1.,origin='lower')
 
     # smooth it a little
     distance = gaussian_filter(distance, sigma = 0.5)
-    print name, 'distance smoothed', numpy.amin(distance), numpy.amax(distance)
+    print(name, 'distance smoothed', numpy.amin(distance), numpy.amax(distance))
     pyplot.imsave('%s_distance_smoothed.png'%name, distance, vmin=-1., vmax=1., origin='lower')
 
     contourObj = cntr.Cntr(X,Y,distance)
@@ -109,9 +109,9 @@ def extract_geometry(mask):
         if poly.is_valid:
             polys.append(poly)
         else:
-            print "invalid shape with %i vertices"%v.shape[0]
+            print(f"invalid shape with {v.shape[0]:d} vertices")
 
-    return mapping(cascaded_union(polys))
+    return mapping(unary_union(polys))
 
 inFile = Dataset('bedmap2.nc')
 

--- a/geometric_features/aggregation/ocean/moc_basins.py
+++ b/geometric_features/aggregation/ocean/moc_basins.py
@@ -113,7 +113,7 @@ def _remove_small_polygons(fc, minArea):
                     else:
                         removedCount += 1
                 if len(outPolygons) > 0:
-                    outShape = shapely.ops.cascaded_union(outPolygons)
+                    outShape = shapely.ops.unary_union(outPolygons)
                     feature['geometry'] = shapely.geometry.mapping(outShape)
                     add = True
         if add:

--- a/geometric_features/feature_collection.py
+++ b/geometric_features/feature_collection.py
@@ -206,7 +206,7 @@ class FeatureCollection(object):
             authors.append(feature['properties']['author'])
             featureNames.append(feature['properties']['name'])
 
-        combinedShape = shapely.ops.cascaded_union(featureShapes)
+        combinedShape = shapely.ops.unary_union(featureShapes)
 
         geometry = shapely.geometry.mapping(combinedShape)
 


### PR DESCRIPTION
`cascaded_union` was deprecated in the latest release of `shapely`.

This merge also fixes some python 2 print statements in affected files.