### PR TITLE
Fix deprecation warning in MOC aggregator

### DIFF
--- a/geometric_features/aggregation/ocean/moc_basins.py
+++ b/geometric_features/aggregation/ocean/moc_basins.py
@@ -107,7 +107,7 @@ def _remove_small_polygons(fc, minArea):
             else:
                 # a MultiPolygon
                 outPolygons = []
-                for polygon in featureShape:
+                for polygon in featureShape.geoms:
                     if polygon.area > minArea:
                         outPolygons.append(polygon)
                     else:


### PR DESCRIPTION
Shapely will soon stop allowing `MultiPolygon` objects to be treated as lists, so we want to use the `.geoms` property for this purpose instead.