### PR TITLE
Fix an issue with the docs and with Azure building the docs

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -17,42 +17,39 @@ jobs:
     displayName: Add conda to PATH
 
   - bash: |
+      set -e
+      eval "$(conda shell.bash hook)"
       conda config --add channels conda-forge
       conda config --set channel_priority strict
-      conda create --yes --quiet --name build python=$PYTHON_VERSION conda conda-build
-    displayName: Create Anaconda build environment
+      conda install --yes python=$PYTHON_VERSION conda conda-build mamba boa
+    displayName: Update conda base environment
 
   - bash: |
       eval "$(conda shell.bash hook)"
-      conda activate build
-      conda build -m "ci/python${PYTHON_VERSION}.yaml" "recipe"
+      # workaround based on recent failures
+      rm /usr/share/miniconda/pkgs/cache/*.json
+      conda mambabuild -m "ci/python${PYTHON_VERSION}.yaml" "recipe"
     displayName: Build geometric_features
 
   - bash: |
+      set -e
       eval "$(conda shell.bash hook)"
-      conda activate build
-      conda create --yes --quiet --name test -c ${CONDA_PREFIX}/conda-bld/ \
-          python=$PYTHON_VERSION geometric_features pytest
+      mamba create --yes --quiet --name test -c ${CONDA_PREFIX}/conda-bld/ \
+          python=$PYTHON_VERSION geometric_features pytest sphinx mock \
+          sphinx_rtd_theme m2r2
     displayName: Create Anaconda test environment
 
   - bash: |
+      set -e
       eval "$(conda shell.bash hook)"
       conda activate test
       pytest --pyargs geometric_features
     displayName: pytest
 
   - bash: |
+      set -e
       eval "$(conda shell.bash hook)"
-      conda activate build
-      conda create --yes --quiet --name docs -c ${CONDA_PREFIX}/conda-bld/ \
-          python=$PYTHON_VERSION geometric_features sphinx mock \
-          sphinx_rtd_theme m2r
-    condition: eq(variables['python.version'], '3.8')
-    displayName: Create Anaconda docs environment
-
-  - bash: |
-      eval "$(conda shell.bash hook)"
-      conda activate docs
+      conda activate test
 
       echo "source branch: $(Build.SourceBranch)"
       echo "target branch: $(System.PullRequest.TargetBranch)"
@@ -134,25 +131,27 @@ jobs:
     displayName: Fix permissions
 
   - bash: |
+      set -e
+      eval "$(conda shell.bash hook)"
       conda config --add channels conda-forge
       conda config --set channel_priority strict
-      conda create --yes --quiet --name build python=$PYTHON_VERSION conda conda-build
-    displayName: Create Anaconda build environment
+      conda install --yes python=$PYTHON_VERSION conda conda-build mamba boa
+    displayName: Update conda base environment
 
   - bash: |
       eval "$(conda shell.bash hook)"
-      conda activate build
-      conda build -m "ci/python${PYTHON_VERSION}.yaml" "recipe"
+      conda mambabuild -m "ci/python${PYTHON_VERSION}.yaml" "recipe"
     displayName: Build geometric_features
 
   - bash: |
+      set -e
       eval "$(conda shell.bash hook)"
-      conda activate build
-      conda create --yes --quiet --name test -c ${CONDA_PREFIX}/conda-bld/ \
+      mamba create --yes --quiet --name test -c ${CONDA_PREFIX}/conda-bld/ \
           python=$PYTHON_VERSION geometric_features pytest
     displayName: Create Anaconda test environment
 
   - bash: |
+      set -e
       eval "$(conda shell.bash hook)"
       conda activate test
       pytest --pyargs geometric_features

--- a/dev-spec.txt
+++ b/dev-spec.txt
@@ -16,4 +16,4 @@ pip
 # Documentation
 sphinx
 sphinx_rtd_theme
-m2r
+m2r2

--- a/geometric_features/docs/parse_quick_start.py
+++ b/geometric_features/docs/parse_quick_start.py
@@ -4,7 +4,7 @@ A script for converting the README.md to a quick-start guide for inclusion
 in the documentation
 """
 
-from m2r import convert
+from m2r2 import convert
 
 
 def build_quick_start():


### PR DESCRIPTION
A recent merge (#178) didn't build the docs but Azure passed even so.

This merge adds checks for errors to Azure, quitting if errors occur.

It also switches to `mamba` for building and installing the package to speed things up.

Finally, this merge replaces the `m2r` package with the `m2r2` package.  The former is no longer being maintained and isn't compatible with the newest version of its dependencies.