### PR TITLE
Remove seed points near islands

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -21,7 +21,11 @@ jobs:
       eval "$(conda shell.bash hook)"
       conda config --add channels conda-forge
       conda config --set channel_priority strict
-      conda install --yes conda conda-build mamba boa
+      conda update --yes --all
+      conda install --yes mamba
+      # workaround based on recent failures
+      rm /usr/share/miniconda/pkgs/cache/*.json
+      mamba install --yes conda-build boa
     displayName: Update conda base environment
 
   - bash: |
@@ -136,7 +140,9 @@ jobs:
       eval "$(conda shell.bash hook)"
       conda config --add channels conda-forge
       conda config --set channel_priority strict
-      conda install --yes conda conda-build mamba boa
+      conda update --yes --all
+      conda install --yes mamba
+      mamba install --yes conda-build boa
     displayName: Update conda base environment
 
   - bash: |

--- a/geometric_data/ocean/point/Equatorial_Pacific_W090.0_N00.0/point.geojson
+++ b/geometric_data/ocean/point/Equatorial_Pacific_W090.0_N00.0/point.geojson
@@ -5,7 +5,7 @@
             "type": "Feature", 
             "properties": {
                 "name": "Equatorial_Pacific_W090.0_N00.0", 
-                "tags": "seed_point", 
+                "tags": "", 
                 "object": "point", 
                 "component": "ocean", 
                 "author": "Todd Ringler"

--- a/geometric_data/ocean/point/Southern_Ocean_Drake_Passage_W070.0_S55.0/point.geojson
+++ b/geometric_data/ocean/point/Southern_Ocean_Drake_Passage_W070.0_S55.0/point.geojson
@@ -5,7 +5,7 @@
             "type": "Feature", 
             "properties": {
                 "name": "Southern_Ocean_Drake_Passage_W070.0_S55.0", 
-                "tags": "seed_point", 
+                "tags": "", 
                 "object": "point", 
                 "component": "ocean", 
                 "author": "Todd Ringler"

--- a/geometric_features/features_and_tags.json
+++ b/geometric_features/features_and_tags.json
@@ -890,7 +890,7 @@
         "seed_point"
       ],
       "Equatorial_Pacific_W090.0_N00.0": [
-        "seed_point"
+        ""
       ],
       "Equatorial_Pacific_W095.0_N00.0": [
         "seed_point"
@@ -950,7 +950,7 @@
         "seed_point"
       ],
       "Southern_Ocean_Drake_Passage_W070.0_S55.0": [
-        "seed_point"
+        ""
       ],
       "Southern_Ocean_Drake_Passage_W070.0_S60.0": [
         "seed_point"


### PR DESCRIPTION
This merge removes ocean seed points near Tierra Del Fuego and the Galapagos Islands.  These seed points are in danger of ending up as an isolated lake in many meshes, so it is not a safe seed point for flood filling the ocean to ensure connectivity.

The Tierra Del Fuego point has caused problems in MPAS-Analysis with the SO12to60 mesh (without ice-shelf cavities).