### PR TITLE
Fix issues with python 3.12 

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,6 +11,8 @@ jobs:
         python.version: '3.10'
       Python311:
         python.version: '3.11'
+      Python312:
+        python.version: '3.12'
 
   steps:
   - bash: echo "##vso[task.prependpath]$CONDA/bin"

--- a/ci/python3.12.yaml
+++ b/ci/python3.12.yaml
@@ -1,0 +1,8 @@
+channel_sources:
+- conda-forge,defaults
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.12.* *_cpython

--- a/geometric_features/test/__init__.py
+++ b/geometric_features/test/__init__.py
@@ -9,7 +9,7 @@ import warnings
 from contextlib import contextmanager
 
 import os
-from distutils import dir_util
+import shutil
 from pytest import fixture
 
 try:
@@ -51,7 +51,7 @@ def loaddatadir(request, tmpdir):
     test_dir, _ = os.path.splitext(filename)
 
     if os.path.isdir(test_dir):
-        dir_util.copy_tree(test_dir, bytes(tmpdir))
+        shutil.copy_tree(test_dir, str(tmpdir))
 
     request.cls.datadir = tmpdir
 


### PR DESCRIPTION
It seems we weren't testing with python 3.12 here and some issues have arisen on conda-forge when trying to run the test with python 3.12 there:
https://github.com/conda-forge/geometric_features-feedstock/pull/31