### PR TITLE
Add Carroll Inlet as a critical passage

### DIFF
--- a/geometric_data/ocean/transect/Carroll_Inlet/transect.geojson
+++ b/geometric_data/ocean/transect/Carroll_Inlet/transect.geojson
@@ -1,0 +1,33 @@
+{
+    "type": "FeatureCollection",
+    "features": [
+        {
+            "type": "Feature",
+            "properties": {
+                "name": "Carroll Inlet",
+                "tags": "Critical_Passage",
+                "object": "transect",
+                "component": "ocean",
+                "author": "Xylar Asay-Davis",
+                "depth": "200.0"
+            },
+            "geometry": {
+                "type": "LineString",
+                "coordinates": [
+                    [
+                        -79.97838,
+                        -72.807268
+                    ],
+                    [
+                        -79.318248,
+                        -73.070876
+                    ],
+                    [
+                        -78.6627,
+                        -73.268643
+                    ]
+                ]
+            }
+        }
+    ]
+}

--- a/geometric_features/features_and_tags.json
+++ b/geometric_features/features_and_tags.json
@@ -1660,6 +1660,9 @@
       "Calabria": [
         "Critical_Land_Blockage"
       ],
+      "Carroll Inlet": [
+        "Critical_Passage"
+      ],
       "Davis Strait": [
         "standard_transport_sections",
         "arctic_transport_sections"


### PR DESCRIPTION
This feature keeps access to Carroll Inlet adjacent to Stange Ice Shelf in the Bellingshausen Sea region of Antarctica.

![image](https://github.com/user-attachments/assets/e3aa3c38-ecea-4fb7-a818-8a875b4fc33e)
![image](https://github.com/user-attachments/assets/4881722f-9c67-4168-abf9-fff07843b289)
