### PR TITLE
Add flags to `pip install` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ To develop `geometric_features` (e.g. to add new features), create and activate
 ```bash
 conda create -y -n mpas_dev --file dev-spec.txt
 conda activate mpas_dev
-python -m pip install -e .
+python -m pip install --no-deps --no-build-isolation -e .
 ```
 
 A typical workflow will look like:

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-$PYTHON -m pip install . --no-deps -vv
+$PYTHON -m pip install --no-deps --no-build-isolation -vv .
 
 cp -r "${SRC_DIR}/geometric_data" "${PREFIX}/share/geometric_data"
 


### PR DESCRIPTION
In this PR I added a few flags to the `python -m pip install [-e] .` command. The flags are:
* `-vv` indicates very verbose output. This flag is used during the CI runs to help with debugging.
* `--no-deps` indicates that pip should not install runtime dependencies from PyPi.
* `--no-build-isolation` indicates that pip should not install build time dependencies from PyPi.