### PR TITLE
Remove unused tag

### DIFF
--- a/geometric_features/features_and_tags.json
+++ b/geometric_features/features_and_tags.json
@@ -890,9 +890,6 @@
       "northGreenland3_oceanExtended": [
         "northGreenland"
       ],
-      "northGreenland4_oceanExtended": [
-        "northGreenland"
-      ],
       "northWestGreenland1_oceanExtended": [
         "northWestGreenland"
       ],


### PR DESCRIPTION
Removes bug in `geometric_features/features_and_tags.json`, in which an unused region was listed. `northGreenland4_oceanExtended` was absorbed by its neighboring regions when extending into ocean, so should no longer be listed in this file.