### PR TITLE
Fix sea-ice historical median features

### DIFF
--- a/geometric_data/seaice/region/April_Historical_Median_Sea_Ice_Extent/region.geojson
+++ b/geometric_data/seaice/region/April_Historical_Median_Sea_Ice_Extent/region.geojson
@@ -5,10 +5,10 @@
         {
             "type": "Feature",
             "properties": {
-                "name": "April Median Sea Ice Extent (1981-2010)",
+                "name": "April Historical Median Sea Ice Extent",
                 "tags": "QGreenland;Historical_Sea_Ice_Extent",
                 "object": "region",
-                "component": "sea ice",
+                "component": "seaice",
                 "author": "Modified by Alex Hager from the QGreenland dataset (doi:10.5281/zenodo.12823307)",
                 "history": "11/06/24 14:26 : ch-fe2 : ahager : /usr/projects/climate/ahager/geometric_features/geometric_data/seaice/region : /usr/projects/climate/ahager/scripts/fix_antimeridian_geojson.py -f april.geojson;"
             },

--- a/geometric_data/seaice/region/August_Historical_Median_Sea_Ice_Extent/region.geojson
+++ b/geometric_data/seaice/region/August_Historical_Median_Sea_Ice_Extent/region.geojson
@@ -5,10 +5,10 @@
         {
             "type": "Feature",
             "properties": {
-                "name": "August Median Sea Ice Extent (1981-2010)",
+                "name": "August Historical Median Sea Ice Extent",
                 "tags": "QGreenland;Historical_Sea_Ice_Extent",
                 "object": "region",
-                "component": "sea ice",
+                "component": "seaice",
                 "author": "Modified by Alex Hager from the QGreenland dataset (doi:10.5281/zenodo.12823307)",
                 "history": "11/06/24 12:43 : ch-fe2 : ahager : /usr/projects/climate/ahager/geometric_features/geometric_data/seaice/region/August_Historical_Median_Sea_Ice_Extent : /usr/projects/climate/ahager/scripts/fix_antimeridian_geojson.py -f region.geojson;"
             },

--- a/geometric_data/seaice/region/December_Historical_Median_Sea_Ice_Extent/region.geojson
+++ b/geometric_data/seaice/region/December_Historical_Median_Sea_Ice_Extent/region.geojson
@@ -5,10 +5,10 @@
         {
             "type": "Feature",
             "properties": {
-                "name": "December Median Sea Ice Extent (1981-2010)",
+                "name": "December Historical Median Sea Ice Extent",
                 "tags": "QGreenland;Historical_Sea_Ice_Extent",
                 "object": "region",
-                "component": "sea ice",
+                "component": "seaice",
                 "author": "Modified by Alex Hager from the QGreenland dataset (doi:10.5281/zenodo.12823307)",
                 "history": "11/06/24 12:55 : ch-fe2 : ahager : /usr/projects/climate/ahager/geometric_features/geometric_data/seaice/region : /usr/projects/climate/ahager/scripts/fix_antimeridian_geojson.py -f December_Historical_Median_Sea_Ice_Extent/region.geojson;"
             },

--- a/geometric_data/seaice/region/February_Historical_Median_Sea_Ice_Extent/region.geojson
+++ b/geometric_data/seaice/region/February_Historical_Median_Sea_Ice_Extent/region.geojson
@@ -5,10 +5,10 @@
         {
             "type": "Feature",
             "properties": {
-                "name": "February Median Sea Ice Extent (1981-2010)",
+                "name": "February Historical Median Sea Ice Extent",
                 "tags": "QGreenland;Historical_Sea_Ice_Extent",
                 "object": "region",
-                "component": "sea ice",
+                "component": "seaice",
                 "author": "Modified by Alex Hager from the QGreenland dataset (doi:10.5281/zenodo.12823307)",
                 "history": "11/06/24 12:55 : ch-fe2 : ahager : /usr/projects/climate/ahager/geometric_features/geometric_data/seaice/region : /usr/projects/climate/ahager/scripts/fix_antimeridian_geojson.py -f February_Historical_Median_Sea_Ice_Extent/region.geojson;"
             },

--- a/geometric_data/seaice/region/January_Historical_Median_Sea_Ice_Extent/region.geojson
+++ b/geometric_data/seaice/region/January_Historical_Median_Sea_Ice_Extent/region.geojson
@@ -5,10 +5,10 @@
         {
             "type": "Feature",
             "properties": {
-                "name": "January Median Sea Ice Extent (1981-2010)",
+                "name": "January Historical Median Sea Ice Extent",
                 "tags": "QGreenland;Historical_Sea_Ice_Extent",
                 "object": "region",
-                "component": "sea ice",
+                "component": "seaice",
                 "author": "Modified by Alex Hager from the QGreenland dataset (doi:10.5281/zenodo.12823307)",
                 "history": "11/06/24 12:56 : ch-fe2 : ahager : /usr/projects/climate/ahager/geometric_features/geometric_data/seaice/region : /usr/projects/climate/ahager/scripts/fix_antimeridian_geojson.py -f January_Historical_Median_Sea_Ice_Extent/region.geojson;"
             },

--- a/geometric_data/seaice/region/July_Historical_Median_Sea_Ice_Extent/region.geojson
+++ b/geometric_data/seaice/region/July_Historical_Median_Sea_Ice_Extent/region.geojson
@@ -5,10 +5,10 @@
         {
             "type": "Feature",
             "properties": {
-                "name": "July Median Sea Ice Extent (1981-2010)",
+                "name": "July Historical Median Sea Ice Extent",
                 "tags": "QGreenland;Historical_Sea_Ice_Extent",
                 "object": "region",
-                "component": "sea ice",
+                "component": "seaice",
                 "author": "Modified by Alex Hager from the QGreenland dataset (doi:10.5281/zenodo.12823307)",
                 "history": "11/06/24 12:56 : ch-fe2 : ahager : /usr/projects/climate/ahager/geometric_features/geometric_data/seaice/region : /usr/projects/climate/ahager/scripts/fix_antimeridian_geojson.py -f July_Historical_Median_Sea_Ice_Extent/region.geojson;"
             },

--- a/geometric_data/seaice/region/June_Historical_Median_Sea_Ice_Extent/region.geojson
+++ b/geometric_data/seaice/region/June_Historical_Median_Sea_Ice_Extent/region.geojson
@@ -5,10 +5,10 @@
         {
             "type": "Feature",
             "properties": {
-                "name": "June Median Sea Ice Extent (1981-2010)",
+                "name": "June Historical Median Sea Ice Extent",
                 "tags": "QGreenland;Historical_Sea_Ice_Extent",
                 "object": "region",
-                "component": "sea ice",
+                "component": "seaice",
                 "author": "Modified by Alex Hager from the QGreenland dataset (doi:10.5281/zenodo.12823307)",
                 "history": "11/06/24 12:56 : ch-fe2 : ahager : /usr/projects/climate/ahager/geometric_features/geometric_data/seaice/region : /usr/projects/climate/ahager/scripts/fix_antimeridian_geojson.py -f June_Historical_Median_Sea_Ice_Extent/region.geojson;"
             },

--- a/geometric_data/seaice/region/March_Historical_Median_Sea_Ice_Extent/region.geojson
+++ b/geometric_data/seaice/region/March_Historical_Median_Sea_Ice_Extent/region.geojson
@@ -5,10 +5,10 @@
         {
             "type": "Feature",
             "properties": {
-                "name": "March Median Sea Ice Extent (1981-2010)",
+                "name": "March Historical Median Sea Ice Extent",
                 "tags": "QGreenland;Historical_Sea_Ice_Extent",
                 "object": "region",
-                "component": "sea ice",
+                "component": "seaice",
                 "author": "Modified by Alex Hager from the QGreenland dataset (doi:10.5281/zenodo.12823307)",
                 "history": "11/06/24 12:57 : ch-fe2 : ahager : /usr/projects/climate/ahager/geometric_features/geometric_data/seaice/region : /usr/projects/climate/ahager/scripts/fix_antimeridian_geojson.py -f March_Historical_Median_Sea_Ice_Extent/region.geojson;"
             },

--- a/geometric_data/seaice/region/May_Historical_Median_Sea_Ice_Extent/region.geojson
+++ b/geometric_data/seaice/region/May_Historical_Median_Sea_Ice_Extent/region.geojson
@@ -5,10 +5,10 @@
         {
             "type": "Feature",
             "properties": {
-                "name": "May Median Sea Ice Extent (1981-2010)",
+                "name": "May Historical Median Sea Ice Extent",
                 "tags": "QGreenland;Historical_Sea_Ice_Extent",
                 "object": "region",
-                "component": "sea ice",
+                "component": "seaice",
                 "author": "Modified by Alex Hager from the QGreenland dataset (doi:10.5281/zenodo.12823307)",
                 "history": "11/06/24 12:57 : ch-fe2 : ahager : /usr/projects/climate/ahager/geometric_features/geometric_data/seaice/region : /usr/projects/climate/ahager/scripts/fix_antimeridian_geojson.py -f May_Historical_Median_Sea_Ice_Extent/region.geojson;"
             },

--- a/geometric_data/seaice/region/November_Historical_Median_Sea_Ice_Extent/region.geojson
+++ b/geometric_data/seaice/region/November_Historical_Median_Sea_Ice_Extent/region.geojson
@@ -5,10 +5,10 @@
         {
             "type": "Feature",
             "properties": {
-                "name": "November Median Sea Ice Extent (1981-2010)",
+                "name": "November Historical Median Sea Ice Extent",
                 "tags": "QGreenland;Historical_Sea_Ice_Extent",
                 "object": "region",
-                "component": "sea ice",
+                "component": "seaice",
                 "author": "Modified by Alex Hager from the QGreenland dataset (doi:10.5281/zenodo.12823307)",
                 "history": "11/06/24 12:57 : ch-fe2 : ahager : /usr/projects/climate/ahager/geometric_features/geometric_data/seaice/region : /usr/projects/climate/ahager/scripts/fix_antimeridian_geojson.py -f November_Historical_Median_Sea_Ice_Extent/region.geojson;"
             },

--- a/geometric_data/seaice/region/October_Historical_Median_Sea_Ice_Extent/region.geojson
+++ b/geometric_data/seaice/region/October_Historical_Median_Sea_Ice_Extent/region.geojson
@@ -5,10 +5,10 @@
         {
             "type": "Feature",
             "properties": {
-                "name": "October Median Sea Ice Extent (1981-2010)",
+                "name": "October Historical Median Sea Ice Extent",
                 "tags": "QGreenland;Historical_Sea_Ice_Extent",
                 "object": "region",
-                "component": "sea ice",
+                "component": "seaice",
                 "author": "Modified by Alex Hager from the QGreenland dataset (doi:10.5281/zenodo.12823307)",
                 "history": "11/06/24 14:38 : ch-fe2 : ahager : /usr/projects/climate/ahager/geometric_features/geometric_data/seaice/region/October_Historical_Median_Sea_Ice_Extent : /usr/projects/climate/ahager/scripts/fix_antimeridian_geojson.py -f region.geojson;"
             },

--- a/geometric_data/seaice/region/September_Historical_Median_Sea_Ice_Extent/region.geojson
+++ b/geometric_data/seaice/region/September_Historical_Median_Sea_Ice_Extent/region.geojson
@@ -5,7 +5,7 @@
         {
             "type": "Feature",
             "properties": {
-                "name": "September Median Sea Ice Extent (1981-2010)",
+                "name": "September Historical Median Sea Ice Extent",
                 "tags": "QGreenland;Historical_Sea_Ice_Extent",
                 "object": "region",
                 "component": "seaice",


### PR DESCRIPTION
The name of the feature needs to be exactly the same as the folder it's in (except ' ' --> '_') and the name of the component needs to be `seaice` instead of `sea ice`.