### PR TITLE
Clean-up on imports and pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,6 @@ repos:
     rev: 5.13.2
     hooks:
       - id: isort
-        exclude: "geometric_features/__init__.py"
 
   # Can run individually with `flynt [file]` or `flynt [source]`
   - repo: https://github.com/ikamensh/flynt

--- a/examples/setup_antarctic_basins.py
+++ b/examples/setup_antarctic_basins.py
@@ -3,10 +3,6 @@
 This script combines Antarctic basins into a single feature file.
 """
 
-# stuff to make scipts work for python 2 and python 3
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
 import matplotlib.pyplot as plt
 
 from geometric_features import GeometricFeatures

--- a/examples/setup_extended_antarctic_basins.py
+++ b/examples/setup_extended_antarctic_basins.py
@@ -4,10 +4,6 @@ This script combines Antarctic basins extended to the continental-shelf break
 into a single feature file.
 """
 
-# stuff to make scipts work for python 2 and python 3
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
 import matplotlib.pyplot as plt
 
 from geometric_features import FeatureCollection, GeometricFeatures

--- a/examples/setup_ice_shelves.py
+++ b/examples/setup_ice_shelves.py
@@ -3,10 +3,6 @@
 This script creates region groups for ice shelves
 """
 
-# stuff to make scipts work for python 2 and python 3
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
 import matplotlib.pyplot as plt
 
 from geometric_features import FeatureCollection, GeometricFeatures

--- a/examples/setup_ocean_critical_passages.py
+++ b/examples/setup_ocean_critical_passages.py
@@ -3,10 +3,6 @@
 This script combines transects defining cricial passages.
 """
 
-# stuff to make scipts work for python 2 and python 3
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
 from geometric_features import GeometricFeatures
 
 # create a GeometricFeatures object that points to a local cache of geometric

--- a/examples/setup_ocean_land_coverage.py
+++ b/examples/setup_ocean_land_coverage.py
@@ -7,10 +7,6 @@ both grounded and floating ice to determine land coverage (thus opening
 up sub-ice-shelf cavities in the ocean around Antarctica.
 """
 
-# stuff to make scipts work for python 2 and python 3
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
 import matplotlib.pyplot as plt
 
 from geometric_features import GeometricFeatures

--- a/examples/setup_ocean_region_groups.py
+++ b/examples/setup_ocean_region_groups.py
@@ -11,10 +11,6 @@ iii) NinoRegionGroups, which includes the Nino3, Nino4, and Nino3.4
     regions.
 """
 
-# stuff to make scipts work for python 2 and python 3
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
 import copy
 
 import matplotlib.pyplot as plt

--- a/examples/setup_ocean_standard_transport_sections.py
+++ b/examples/setup_ocean_standard_transport_sections.py
@@ -4,10 +4,6 @@ This script creates region groups for the standard set of transport sections,
 all of which have the "standard_transport_sections" tag.
 """
 
-# stuff to make scipts work for python 2 and python 3
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
 from geometric_features import GeometricFeatures
 
 # create a GeometricFeatures object that points to a local cache of geometric

--- a/geometric_features/__init__.py
+++ b/geometric_features/__init__.py
@@ -1,14 +1,9 @@
+from geometric_features.__main__ import (combine_features, difference_features,
+                                         fix_features_at_antimeridian,
+                                         merge_features, plot_features,
+                                         set_group_name, simplify_features,
+                                         split_features, tag_features)
+from geometric_features.feature_collection import (FeatureCollection,
+                                                   read_feature_collection)
 from geometric_features.geometric_features import GeometricFeatures
-
-from geometric_features.feature_collection import FeatureCollection, \
-     read_feature_collection
-
-from geometric_features.__main__ import combine_features, difference_features, \
-    fix_features_at_antimeridian, merge_features, plot_features, \
-    set_group_name, split_features, simplify_features, tag_features
-
 from geometric_features.utils import write_feature_names_and_tags
-
-
-__version_info__ = (1, 6, 0)
-__version__ = '.'.join(str(vi) for vi in __version_info__)

--- a/geometric_features/__init__.py
+++ b/geometric_features/__init__.py
@@ -1,6 +1,3 @@
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
-
 from geometric_features.geometric_features import GeometricFeatures
 
 from geometric_features.feature_collection import FeatureCollection, \

--- a/geometric_features/__main__.py
+++ b/geometric_features/__main__.py
@@ -1,6 +1,3 @@
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
 import argparse
 import os
 

--- a/geometric_features/__main__.py
+++ b/geometric_features/__main__.py
@@ -1,10 +1,10 @@
 import argparse
 import os
 
-import geometric_features
-from geometric_features import GeometricFeatures
 from geometric_features.feature_collection import (FeatureCollection,
                                                    read_feature_collection)
+from geometric_features.geometric_features import GeometricFeatures
+from geometric_features.version import __version__
 
 
 def combine_features():
@@ -25,7 +25,7 @@ def combine_features():
                         metavar="PATH", default="features.geojson")
     parser.add_argument('-v', '--version',
                         action='version',
-                        version=f'geometric_features {geometric_features.__version__}',
+                        version=f'geometric_features {__version__}',
                         help="Show version number and exit")
 
     args = parser.parse_args()
@@ -54,7 +54,7 @@ def difference_features():
                         metavar="PATH", default="features.geojson")
     parser.add_argument('-v', '--version',
                         action='version',
-                        version=f'geometric_features {geometric_features.__version__}',
+                        version=f'geometric_features {__version__}',
                         help="Show version number and exit")
 
     args = parser.parse_args()
@@ -79,7 +79,7 @@ def fix_features_at_antimeridian():
                         metavar="PATH", default="features.geojson")
     parser.add_argument('-v', '--version',
                         action='version',
-                        version=f'geometric_features {geometric_features.__version__}',
+                        version=f'geometric_features {__version__}',
                         help="Show version number and exit")
 
     args = parser.parse_args()
@@ -121,7 +121,7 @@ def merge_features():
                         metavar="PATH")
     parser.add_argument('-v', '--version',
                         action='version',
-                        version=f'geometric_features {geometric_features.__version__}',
+                        version=f'geometric_features {__version__}',
                         help="Show version number and exit")
 
     args = parser.parse_args()
@@ -166,7 +166,7 @@ def plot_features():
                         " (0.0 indicates skip subdivision)")
     parser.add_argument('-v', '--version',
                         action='version',
-                        version=f'geometric_features {geometric_features.__version__}',
+                        version=f'geometric_features {__version__}',
                         help="Show version number and exit")
 
     args = parser.parse_args()
@@ -188,7 +188,8 @@ def plot_features():
             figsize = (12, 9)
         fig = fc.plot(mapType, args.max_length, figsize)
 
-        plotFileName = f'{os.path.splitext(args.feature_file)[0]}_{mapType}.png'
+        plotFileName = \
+            f'{os.path.splitext(args.feature_file)[0]}_{mapType}.png'
 
         fig.savefig(plotFileName)
 
@@ -208,7 +209,7 @@ def set_group_name():
                         required=True)
     parser.add_argument('-v', '--version',
                         action='version',
-                        version=f'geometric_features {geometric_features.__version__}',
+                        version=f'geometric_features {__version__}',
                         help="Show version number and exit")
 
     args = parser.parse_args()
@@ -237,7 +238,7 @@ def simplify_features():
                         metavar="PATH", default="features.geojson")
     parser.add_argument('-v', '--version',
                         action='version',
-                        version=f'geometric_features {geometric_features.__version__}',
+                        version=f'geometric_features {__version__}',
                         help="Show version number and exit")
     args = parser.parse_args()
 
@@ -262,7 +263,7 @@ def split_features():
                         metavar="PATH", default="./geometric_data")
     parser.add_argument('-v', '--version',
                         action='version',
-                        version=f'geometric_features {geometric_features.__version__}',
+                        version=f'geometric_features {__version__}',
                         help="Show version number and exit")
     args = parser.parse_args()
 
@@ -291,7 +292,7 @@ def tag_features():
                         metavar="PATH", default="features.geojson")
     parser.add_argument('-v', '--version',
                         action='version',
-                        version=f'geometric_features {geometric_features.__version__}',
+                        version=f'geometric_features {__version__}',
                         help="Show version number and exit")
     args = parser.parse_args()
 

--- a/geometric_features/download.py
+++ b/geometric_features/download.py
@@ -1,6 +1,3 @@
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
 import os
 from urllib.request import pathname2url
 

--- a/geometric_features/feature_collection.py
+++ b/geometric_features/feature_collection.py
@@ -1,6 +1,3 @@
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
 import json
 
 try:

--- a/geometric_features/geometric_features.py
+++ b/geometric_features/geometric_features.py
@@ -1,6 +1,3 @@
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
 import json
 import os
 from importlib.resources import files as imp_res_files

--- a/geometric_features/plot.py
+++ b/geometric_features/plot.py
@@ -1,6 +1,3 @@
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
 import cartopy.crs
 import cartopy.feature
 import matplotlib.pyplot as plt

--- a/geometric_features/utils.py
+++ b/geometric_features/utils.py
@@ -1,6 +1,3 @@
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
 import datetime
 import glob
 import json

--- a/geometric_features/version.py
+++ b/geometric_features/version.py
@@ -1,0 +1,2 @@
+__version_info__ = (1, 6, 0)
+__version__ = '.'.join(str(vi) for vi in __version_info__)

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ import re
 from setuptools import find_packages, setup
 
 here = os.path.abspath(os.path.dirname(__file__))
-with open(os.path.join(here, 'geometric_features', '__init__.py')) as f:
+with open(os.path.join(here, 'geometric_features', 'version.py')) as f:
     init_file = f.read()
 
 version = re.search(r'{}\s*=\s*[(]([^)]*)[)]'.format('__version_info__'),
@@ -49,7 +49,7 @@ setup(name='geometric_features',
                      'difference_features = '
                      'geometric_features.__main__:difference_features',
                      'fix_features_at_antimeridian = '
-                     'geometric_features.__main__:fix_features_at_antimeridian',
+                     'geometric_features.__main__:fix_features_at_antimeridian',  # noqa: E501
                      'merge_features = '
                      'geometric_features.__main__:merge_features',
                      'plot_features = '


### PR DESCRIPTION
This merge removes and very old `__future__` imports needed for python 2 support.

It also makes changes needed to allow `isort` to include `geometric_feature/__init__.py`:
* moves version info to `version.py`
* updates `__main__.py` to not use shortcut in `__init__.py` and to use version info from `version.py`.
* sorts imports in `__init__.py`.