### PR TITLE
Switch CI from miniconda to micromamba

### DIFF
--- a/.github/workflows/build_workflow.yml
+++ b/.github/workflows/build_workflow.yml
@@ -87,21 +87,21 @@ jobs:
 
       - if: ${{ steps.skip_check.outputs.should_skip != 'true' }}
         name: Set up Conda Environment
-        uses: conda-incubator/setup-miniconda@v3
+        uses: mamba-org/setup-micromamba@v2
         with:
-          activate-environment: "geometric_features_ci"
-          miniforge-version: latest
-          channels: conda-forge
-          channel-priority: strict
-          auto-update-conda: true
-          python-version: ${{ matrix.python-version }}
+          environment-name: geometric_features_dev
+          init-shell: bash
+          condarc: |
+            channel_priority: strict
+            channels:
+                - conda-forge
+          create-args: >-
+            python=${{ matrix.python-version }}
 
       - if: ${{ steps.skip_check.outputs.should_skip != 'true' }}
         name: Install geometric_features
         run: |
-          conda create -n geometric_features_dev --file dev-spec.txt \
-              python=${{ matrix.python-version }}
-          conda activate geometric_features_dev
+          conda install -y --file dev-spec.txt python=${{ matrix.python-version }}
           python -m pip install --no-deps --no-build-isolation -vv -e .
 
       - if: ${{ steps.skip_check.outputs.should_skip != 'true' }}
@@ -110,7 +110,6 @@ jobs:
            CHECK_IMAGES: False
         run: |
           set -e
-          conda activate geometric_features_dev
           pip check
           pytest --pyargs geometric_features
           combine_features -v
@@ -126,7 +125,6 @@ jobs:
       - if: ${{ steps.skip_check.outputs.should_skip != 'true' }}
         name: Build Sphinx Docs
         run: |
-          conda activate geometric_features_dev
           # sphinx-multiversion expects at least a "main" branch
           git branch main || echo "branch main already exists."
           cd docs

--- a/.github/workflows/docs_workflow.yml
+++ b/.github/workflows/docs_workflow.yml
@@ -36,35 +36,33 @@ jobs:
 
       - if: ${{ steps.skip_check.outputs.should_skip != 'true' }}
         name: Set up Conda Environment
-        uses: conda-incubator/setup-miniconda@v3
+        uses: mamba-org/setup-micromamba@v2
         with:
-          activate-environment: "geometric_features_ci"
-          miniforge-version: latest
-          channels: conda-forge
-          channel-priority: strict
-          auto-update-conda: true
-          python-version: ${{ env.PYTHON_VERSION }}
+          environment-name: pyremap_dev
+          init-shell: bash
+          condarc: |
+            channel_priority: strict
+            channels:
+                - conda-forge
+          create-args: >-
+            python=${{ env.PYTHON_VERSION }}
 
       - if: ${{ steps.skip_check.outputs.should_skip != 'true' }}
         name: Install geometric_features
         run: |
           git config --global url."https://github.com/".insteadOf "git@github.com:"
-          conda create -n geometric_features_dev --file dev-spec.txt \
-            python=${{ env.PYTHON_VERSION }}
-          conda activate geometric_features_dev
+          conda install -y --file dev-spec.txt python=${{ env.PYTHON_VERSION }}
           python -m pip install -vv --no-deps --no-build-isolation -e .
 
       - name: Build Sphinx Docs
         run: |
           set -e
-          conda activate geometric_features_dev
           pip check
           cd docs
           sphinx-multiversion . _build/html
       - name: Copy Docs and Commit
         run: |
           set -e
-          conda activate geometric_features_dev
           pip check
           cd docs
           # gh-pages branch must already exist


### PR DESCRIPTION
This PR switches CI to use the `setup-micromamba` GitHub action instead of the `setup-miniconda` GitHub action, in an effort to fix CI crashes caused by the latest `miniconda` version. 