### PR TITLE
Fix `pre-commit` workflow and other CI updates/cleanup

### DIFF
--- a/.github/workflows/build_workflow.yml
+++ b/.github/workflows/build_workflow.yml
@@ -14,6 +14,8 @@ on:
 env:
   CANCEL_OTHERS: false
   PATHS_IGNORE: '["**/README.md", "**/docs/**"]'
+  # Static python version for setting up pre-commit linting
+  PYTHON_VERSION: "3.13"
 
 jobs:
   pre-commit-hooks:
@@ -32,10 +34,10 @@ jobs:
         uses: actions/checkout@v4
 
       - if: ${{ steps.skip_check.outputs.should_skip != 'true' }}
-        name: Set up Python 3.10
+        name: Set up Python ${{ env.PYTHON_VERSION }}
         uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: ${{ env.PYTHON_VERSION }}
 
       - if: ${{ steps.skip_check.outputs.should_skip != 'true' }}
         id: file_changes

--- a/.github/workflows/pre_commit_update_workflow.yml
+++ b/.github/workflows/pre_commit_update_workflow.yml
@@ -9,10 +9,13 @@ on:
     # 4. Entry: Month of the year when the process will be started [1-12]
     # 5. Entry: Weekday when the process will be started [0-6] [0 is Sunday]
     - cron: '0 8 * * 3'
+  # Allow manual triggering of the workflow
+  workflow_dispatch:
 
 env:
   UP_TO_DATE: false
-  PYTHON_VERSION: "3.10"
+  PYTHON_VERSION: "3.13"
+  REVIEWERS: "altheaden,xylar,andrewdnolan"
 
 jobs:
   auto-update:
@@ -20,16 +23,30 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
+      - name: Set up Conda Environment
+        uses: mamba-org/setup-micromamba@v2
         with:
-          python-version: ${{ env.PYTHON_VERSION }}
+          environment-name: pre_commit_dev
+          init-shell: bash
+          condarc: |
+            channel_priority: strict
+            channels:
+                - conda-forge
+          create-args: >-
+            python=${{ env.PYTHON_VERSION }}
 
-      - name: Install pre-commit
-        run: pip install pre-commit
+      - name: Install pre-commit and gh
+        run: |
+          eval "$(micromamba shell hook --shell bash)"
+          micromamba activate pre_commit_dev
+          # permissions issue with gh 2.76.0
+          conda install -y pre-commit "gh !=2.76.0"
+          gh --version
 
       - name: Apply and commit updates
         run: |
+          eval "$(micromamba shell hook --shell bash)"
+          micromamba activate pre_commit_dev
           git clone https://github.com/MPAS-Dev/geometric_features.git update-pre-commit-deps
           cd update-pre-commit-deps
           # Configure git using GitHub Actions credentials.
@@ -62,7 +79,7 @@ jobs:
           --title "Update pre-commit and its dependencies" \
           --body "This PR was auto-generated to update pre-commit and its dependencies." \
           --head update-pre-commit-deps \
-          --reviewer altheaden,xylar \
+          --reviewer ${{ env.REVIEWERS }} \
           --label ci
         env:
           GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
This PR expands on some of the changes made in #136 to add some fixes and updates to various CI workflows. The changes include:
1. All static (non-matrix) versions of python used in CI have been updated to 3.13
2. `PYTHON_VERSION` is now defined in all workflow files for consistency
3. `REVIEWERS` variable is now used to list the reviewers instead of a magic string to make things more readable
4. `pre_commit_update_workflow.yml` has been fixed to use conda in to avoid a bug with `gh` which was causing permissions errors in workflow runs
5. `workflow_dispatch` has been added to `pre_commit_update_workflow.yml` CI workflow to allow manual triggering

@xylar Review checklist:
* [ ] Add @andrewdnolan as maintainer (if he isn't already)