### PR TITLE
Implement two-token method in pre-commit CI

### DIFF
--- a/.github/workflows/pre_commit_update_workflow.yml
+++ b/.github/workflows/pre_commit_update_workflow.yml
@@ -14,39 +14,25 @@ on:
 
 env:
   UP_TO_DATE: false
-  PYTHON_VERSION: "3.13"
+  PYTHON_VERSION: "3.10"
   REVIEWERS: "altheaden,xylar,andrewdnolan"
 
 jobs:
   auto-update:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v4
 
-      - name: Set up Conda Environment
-        uses: mamba-org/setup-micromamba@v2
+      - name: Set up Python
+        uses: actions/setup-python@v5
         with:
-          environment-name: pre_commit_dev
-          init-shell: bash
-          condarc: |
-            channel_priority: strict
-            channels:
-                - conda-forge
-          create-args: >-
-            python=${{ env.PYTHON_VERSION }}
+          python-version: ${{ env.PYTHON_VERSION }}
 
-      - name: Install pre-commit and gh
-        run: |
-          eval "$(micromamba shell hook --shell bash)"
-          micromamba activate pre_commit_dev
-          # permissions issue with gh 2.76.0
-          conda install -y pre-commit "gh !=2.76.0"
-          gh --version
+      - name: Install pre-commit
+        run: pip install pre-commit
 
       - name: Apply and commit updates
         run: |
-          eval "$(micromamba shell hook --shell bash)"
-          micromamba activate pre_commit_dev
           git clone https://github.com/MPAS-Dev/geometric_features.git update-pre-commit-deps
           cd update-pre-commit-deps
           # Configure git using GitHub Actions credentials.
@@ -55,12 +41,10 @@ jobs:
           git checkout -b update-pre-commit-deps
           pre-commit autoupdate
           git add .
-          # Either there are changes, in which case we commit them, or there are no changes,
-          # in which case we can skip the push & pr-create jobs
-          git commit -m "Update pre-commit dependencies" \
-          || ( echo "UP_TO_DATE=true" >> "$GITHUB_ENV")
+          # The second command will fail if no changes were present, so we ignore it
+          git commit -m "Update pre-commit dependencies" || ( echo "UP_TO_DATE=true" >> "$GITHUB_ENV")
 
-      - name: Push Changes
+      - name: Push Changes with github-actions bot
         if: ${{ env.UP_TO_DATE == 'false' }}
         uses: ad-m/github-push-action@master
         with:
@@ -71,10 +55,14 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
 
-      - name: Make PR and add reviewers and labels
+      - name: Create PR with github-actions bot
         if: ${{ env.UP_TO_DATE == 'false' }}
         run: |
           cd update-pre-commit-deps
+          # Close any existing PR and replace with most up-to-date changes
+          gh pr close update-pre-commit-deps \
+          --comment "This PR was closed to create a new, updated PR." || \
+          echo "No existing PR to close and replace."
           gh pr create \
           --title "Update pre-commit and its dependencies" \
           --body "This PR was auto-generated to update pre-commit and its dependencies." \
@@ -84,3 +72,19 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
 
+      - name: Add reviewers and labels with PAT
+        if: ${{ env.UP_TO_DATE == 'false' }}
+        run: |
+          cd update-pre-commit-deps
+
+          gh pr edit --add-label ci
+
+          IFS=',' read -ra reviewers <<< "${REVIEWERS}"
+          for reviewer in "${reviewers[@]}"; do
+            echo "Adding reviewer: $reviewer"
+            gh pr edit --add-reviewer "$reviewer"
+          done
+
+        env:
+          REVIEWERS: ${{ env.REVIEWERS }}
+          GH_TOKEN: ${{ secrets.GH_CLI_TOKEN }}


### PR DESCRIPTION
This PR implements a two-token solution that fixes the permissions errors we're seeing with the pre-commit update job. 

Additionally, it simplifies environment setup, improving compatibility, and enhancing automation of pull request creation and management. The workflow now uses a standard Python setup instead of Conda/Micromamba, ensures the correct reviewers and labels are added, and handles existing pull requests more robustly.