### PR TITLE
Fix pre-commit update action (again)

### DIFF
--- a/.github/workflows/pre_commit_update_workflow.yml
+++ b/.github/workflows/pre_commit_update_workflow.yml
@@ -67,7 +67,6 @@ jobs:
           --title "Update pre-commit and its dependencies" \
           --body "This PR was auto-generated to update pre-commit and its dependencies." \
           --head update-pre-commit-deps \
-          --reviewer ${{ env.REVIEWERS }} \
           --label ci
         env:
           GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
This pull request makes a minor update to the pre-commit update workflow configuration. The change removes the automatic assignment of reviewers when creating pull requests for pre-commit dependency updates.