### PR TITLE
Drop support for Python 3.9

### DIFF
--- a/.github/workflows/build_workflow.yml
+++ b/.github/workflows/build_workflow.yml
@@ -63,7 +63,7 @@ jobs:
         shell: bash -l {0}
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
       fail-fast: false
     steps:
       - id: skip_check

--- a/ci/python3.9.yaml
+++ b/ci/python3.9.yaml
@@ -1,8 +1,0 @@
-channel_sources:
-- conda-forge,defaults
-pin_run_as_build:
-  python:
-    min_pin: x.x
-    max_pin: x.x
-python:
-- 3.9.* *_cpython

--- a/dev-spec.txt
+++ b/dev-spec.txt
@@ -2,7 +2,6 @@
 # $ conda create --name <env> --file <this file>
 
 # Base
-python>=3.9
 cartopy
 matplotlib-base
 numpy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,10 +18,9 @@ description = """\
     """
 license = {file = "LICENSE"}
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 classifiers = [
     # these are only for searching/browsing projects on PyPI
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,11 +25,11 @@ build:
 
 requirements:
   host:
-    - python >=3.9
+    - python >=3.10
     - pip
     - setuptools >=60
   run:
-    - python >=3.9
+    - python >=3.10
     - cartopy
     - matplotlib-base
     - numpy


### PR DESCRIPTION
This PR drops support for Python 3.9 and removes various places where we test with different python versions, such as in CI.